### PR TITLE
Implement time-sliced entrance flow-field scheduler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ add_executable(bee_sim
   src/sim/bee.c
   src/sim/bee_path.c
   src/sim/sim.c
+  src/path/path_core.c
+  src/path/path_fields.c
+  src/path/path_scheduler.c
+  src/path/path_debug.c
   src/world/hex_world.c
   src/world/tiles/tile_core.c
   src/world/tiles/flower/tile_flower.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(bee_sim
   src/sim/bee_path.c
   src/sim/sim.c
   src/path/path_core.c
+  src/path/path_cost.c
   src/path/path_fields.c
   src/path/path_scheduler.c
   src/path/path_debug.c

--- a/docs/bee_pathfinding_v2_design.md
+++ b/docs/bee_pathfinding_v2_design.md
@@ -1,0 +1,223 @@
+# Bee Pathfinding v2 — Flow-Field Design Doc
+
+## Context
+
+The current navigation stack in `src/sim/bee_path.c` performs per-bee steering by probing for
+collision-free lines of sight, leaning on heuristics around the hive entrance and velocity
+alignment. While this avoids heavy graph search per bee, it does not exploit the structure of the
+hexagonal world (`HexWorld`) or the extensive per-tile data already available on `HexTile`
+(`base_cost`, `passable`, `hive_storage_slot`, etc.). The existing API, `bee_path_plan`, returns a
+`BeePathPlan` populated with a direction vector and optional intermediate waypoint, and is invoked
+from the simulation loop in `src/sim/sim.c` via the `SimState` arrays (`x`, `y`, `target_pos_x`,
+`mode`, `intent`, ...).
+
+Bee Pathfinding v2 replaces that heuristic layer with precomputed flow-fields over the hex map. The
+pathfinding system emits per-tile "policy" arrows that bees can sample each frame. This design keeps
+rendering, bee state machines, and physics untouched while providing higher-quality global routing
+with tight CPU budgets.
+
+## Goals
+
+* Reuse the existing `HexWorld` tile graph to provide deterministic navigation toward multiple goal
+  classes (entrances, unload/storage cells, viable flowers).
+* Expose a stable, lightweight query API that the sim loop can call instead of `bee_path_plan`,
+  returning a world-space direction derived from the flow-field.
+* Support dynamic costs influenced by congestion (per-tile flow capacity), hazards, wind, and user
+  edits, with tight control over recomputation time.
+* Supply debugging overlays (distance heatmaps, arrow fields) that can be toggled in the existing
+  renderer for introspection without changing bee rendering.
+
+## File Layout
+
+New pathfinding code lives under `include/path/` and `src/path/`, isolating the flow-field logic from
+simulation and rendering modules.
+
+```
+include/
+  path/path.h                 // public queries and goal definitions
+  path/path_cost.h            // dynamic cost controls and dirty markers
+  path/path_fields.h          // read-only field views for overlays/tests
+  path/path_scheduler.h       // recompute cadence and test hooks
+
+src/path/
+  path_core.c                 // graph prep, goal set extraction, handles
+  path_cost.c                 // effective tile costs and dirty tracking
+  path_fields.c               // multi-source Dijkstra solver & double buffers
+  path_scheduler.c            // time slicing, per-goal budgets, dirties
+  path_debug.c                // overlay generation for renderer/UI
+```
+
+No other subsystem includes these `.c` files directly; they interact via the headers above.
+
+## Public API
+
+### `include/path/path.h`
+
+* `typedef enum PathGoal { ... } PathGoal;` enumerates goal sets that matter to bees. Initial values
+  cover hive entrances (`HEX_TERRAIN_HIVE_ENTRANCE`), unload/storage tiles (`HexTile::hive_storage_slot`
+  >= 0), and viable flower tiles (`hex_world_tile_is_floral`).
+* Lifecycle functions: `bool path_init(const HexWorld *world, const Params *params);` and
+  `void path_shutdown(void);` mirror how `sim_init` and `sim_shutdown` manage `SimState` and
+  `HexWorld` lifetimes.
+* Per-frame update: `void path_update(const HexWorld *world, const Params *params, float dt);` gives
+  the scheduler a budgeted timeslice, similar to how `sim_update` advances bee state.
+* Bee queries: `bool path_query_direction(PathGoal goal, size_t tile_index, Vec2 *dir_world_out);`
+  returns a normalized direction vector centered on the tile retrieved by
+  `hex_world_tile_from_world`. A variant `path_query_direction_biased` accepts a
+  `PathBias` struct (containing nearby flower desirability) so scouts can blend the global policy
+  with opportunistic local pulls.
+* UI helpers: `const size_t *path_goals(PathGoal goal, int *count_out);` exposes the current goal
+  indices for overlays/debug panels.
+
+### `include/path/path_cost.h`
+
+This header lets other systems publish cost adjustments without understanding the solver.
+
+* Coefficient setters such as `path_cost_set_coeffs(float alpha, float beta, float gamma);` map onto
+  user-tunable fields that already exist in `Params` (`bee_speed_mps`, `bee_seek_accel`, etc.).
+* Dirties: `void path_cost_mark_dirty(size_t tile_index);` and
+  `void path_cost_mark_many_dirty(const size_t *indices, int count);` are used by congestion updates
+  in `sim_update` (when `SimState::path_waypoint_x` shows tile crossings), hive editing tools in the
+  UI, or weather systems.
+
+### `include/path/path_fields.h`
+
+Renderer and tooling modules (`src/render`, `src/ui`) can pull raw buffers to visualize the flow
+fields.
+
+* `const float *path_field_dist(PathGoal goal);` exposes per-tile distances.
+* `const uint8_t *path_field_next(PathGoal goal);` encodes which neighbor (0–5) minimizes cost.
+* `uint32_t path_field_stamp(PathGoal goal);` increments whenever a field fully recomputes so
+  overlays know when to refresh vertex buffers.
+
+### `include/path/path_scheduler.h`
+
+* `void path_sched_set_budget_ms(float per_frame_ms);` lets the app expose a slider alongside
+  existing params (see `src/ui/ui_params.c`).
+* `void path_sched_set_goal_rate(PathGoal goal, float hz);` tunes cadence per goal class (entrances
+  update more frequently than flowers).
+* `void path_sched_force_full_recompute(PathGoal goal);` is compiled under test builds so automated
+  checks in `tests/` can assert convergence.
+
+## Responsibilities
+
+### Graph Assembly (`src/path/path_core.c`)
+
+* Cache axial neighbor indices for every tile in `HexWorld::tiles`. Use the existing axial bounds
+  (`q_min`, `q_max`, `r_min`, `r_max`) to clamp out-of-bounds neighbors and skip
+  `HexTile::passable == false` (walls, water).
+* Build goal sets directly from tile data:
+  * Entrances: tiles with `terrain == HEX_TERRAIN_HIVE_ENTRANCE`.
+  * Unload: tiles where `HexTile::hive_storage_slot >= 0` or `hex_world_hive_preferred_unload`
+    resolves.
+  * Flowers: indices returned by `SimState::floral_tile_indices` filtered by positive
+    `HexTile::nectar_stock`.
+* Provide small opaque handles so other modules refer to goal sets without holding pointers.
+
+### Cost Aggregation (`src/path/path_cost.c`)
+
+* Maintain per-tile arrays for the cost components: base terrain (`HexTile::base_cost`), congestion,
+  hazards, wind. Congestion comes from an EMA computed in `sim_update` using the bees' tile indices;
+  store the smoothed density and translate to penalties via
+  `penalty = max(0, density / flow_capacity - 1)^2` (`flow_capacity` already lives on `HexTile`).
+* Track a byte `dirty_flags[tile_index]`. Whenever any component changes beyond a threshold, set the
+  flag and enqueue the tile for the scheduler.
+* Compute `effective_cost[index] = base + alpha * congestion + beta * wind + gamma * hazard` on
+  demand when the solver relaxes an edge.
+
+### Flow-Field Solver (`src/path/path_fields.c`)
+
+* For each `PathGoal`, allocate double-buffered arrays `dist[2][tile_count]` and
+  `next[2][tile_count]`. Buffer indices swap only after the solver empties its priority queue.
+* Store the ongoing Dijkstra frontier in a binary heap of `(tile_index, distance)` plus visited flags
+  to resume across frames.
+* On initialization, push all tiles in the goal set with distance 0. Relax neighbors using axial
+  offsets. Edge traversal cost is `distance[u] + move_cost(u, v)`, where `move_cost` adds the
+  effective cost of entering `v` and any directional wind penalty.
+* Incremental updates: when `dirty_flags` indicate a change, reinsert affected tiles with `+∞`
+  distance so the frontier reflows locally instead of recomputing the entire map.
+* When the queue runs dry, copy results into the inactive buffers, increment `stamp`, and atomically
+  swap the exposed pointers.
+
+### Scheduler (`src/path/path_scheduler.c`)
+
+* Track per-goal cadence timers and a shared millisecond budget (default 1–2 ms per frame). Use the
+  app's delta time from `path_update` to decrement timers, similar to how the sim throttles floral
+  regeneration (`SimState::floral_clock_sec`).
+* Each `path_update` call repeatedly picks the stalest goal whose timer expired and advances its
+  solver for as many pop-relax steps as the budget allows. Abort when budget consumed or the queue is
+  empty.
+* When a goal finishes, clear its timer, rotate it to the back of a small priority queue, and perform
+  the buffer swap described above.
+
+### Debug Overlays (`src/path/path_debug.c`)
+
+* Sample one arrow per N tiles (configurable) based on `path_field_next`. Convert axial directions to
+  world coordinates via `hex_world_axial_to_world` and store them in a `RenderView`-compatible vertex
+  buffer.
+* Provide heatmap textures derived from `path_field_dist` so the renderer can toggle them like the
+  nectar heatmap in `hex_world_apply_palette`.
+
+## Simulation Integration
+
+`src/sim/sim.c` replaces calls to `bee_path_plan` with the new path API.
+
+1. Convert bee world position to a tile index using `hex_world_tile_from_world`. If the bee is
+   outside the grid, steer back toward the closest valid center (existing logic already clamps
+   positions; reuse `hex_world_axial_round`).
+2. Select a `PathGoal` based on `SimState::intent[index]` and `SimState::inside_hive_flag[index]`:
+   * Returning bees → `PATH_GOAL_ENTRANCE`.
+   * Bees carrying nectar in the hive → `PATH_GOAL_UNLOAD`.
+   * Explorers/scouts → `PATH_GOAL_FLOWERS_NEAR`.
+3. Call `path_query_direction(goal, tile_index, &dir)`. Blend `dir` with the existing steering vector
+   (jitter, avoidance) before integrating velocity using `bee_seek_accel` and `bee_speed_mps`.
+4. If `path_query_direction` fails (field not ready or tile unreachable), fall back to the current
+   heuristic in `bee_path_plan` but log a throttled warning for telemetry.
+
+`bee_path_plan` remains temporarily for fallback and to minimize disruption to other behaviors while
+Bee Pathfinding v2 rolls out.
+
+## Dynamic Inputs
+
+* **Congestion**: `sim_update` already tracks bee positions; reuse those loops to increment a per-tile
+  crossing counter each tick. Every 0.1–0.2 s, convert counts to flow rates, smooth with an EMA, and
+  call `path_cost_mark_dirty` for tiles whose density changed more than 5%.
+* **Terrain editing**: When the UI modifies hive walls or toggles deposit slots, mark the affected
+  tiles dirty and rebuild goal sets if a tile switches between passable/impassable states.
+* **Flower viability**: `SimState::floral_tile_indices` contains current floral tiles. When a tile's
+  `HexTile::nectar_stock` crosses a viability threshold, update the goal set for
+  `PATH_GOAL_FLOWERS_NEAR` and force a recompute via the scheduler.
+
+## Parameters & Defaults
+
+Expose new knobs in `Params` (hooked up through `src/config` and `src/ui`):
+
+* `path_budget_ms_per_frame` default 1.5 ms (`path_sched_set_budget_ms`).
+* Goal cadences: entrances/unload 10 Hz, flowers 3 Hz (`path_sched_set_goal_rate`).
+* Cost weights: `alpha_congestion = 1.0`, `beta_wind = 0.0`, `gamma_hazard = 2.0`.
+* Base terrain costs seeded from `HexTile::base_cost` but clamped so hive walls remain impassable.
+
+## Testing & Telemetry
+
+* Functional smoke tests: painting a wall in the hive UI (`src/ui`) should reroute bees within 0.5 s;
+  reducing `HexTile::base_cost` on an entrance should increase flow through it.
+* Performance counters: record per-goal relax steps/sec and queue sizes in the app telemetry panel
+  (`SimState::log_*` style). The scheduler should never exceed its budget; expose actual usage in the
+  debug HUD.
+* Robustness: when a bee stands on a tile with `next == 255`, steer toward the goal center using
+  existing fallback logic and log once per second.
+
+## Rollout Plan
+
+1. **PR1 – Graph & flow-field skeleton:** Implement core neighbors, goal extraction for hive
+   entrances, full Dijkstra recompute, and a basic overlay. Wire up `path_init`, `path_update`, and
+   `path_query_direction` for entrances only.
+2. **PR2 – Scheduler & buffering:** Add incremental stepping, per-goal cadences, buffer swapping, and
+   stamps. Integrate with app parameters for the per-frame budget.
+3. **PR3 – Dynamic costs:** Implement congestion tracking in `sim_update`, hazard/wind fields, dirty
+   propagation, and incremental relaxation.
+4. **PR4 – Flower goals & biases:** Populate flower goal sets, add the biased query hook, and replace
+   most `bee_path_plan` calls.
+5. **PR5 – Polish & observability:** Optional wind integration, UI sliders, HUD stats, and extended
+   tests.
+

--- a/include/path/path.h
+++ b/include/path/path.h
@@ -12,6 +12,7 @@
 typedef enum PathGoal {
     PATH_GOAL_ENTRANCE = 0,
     PATH_GOAL_UNLOAD = 1,
+    PATH_GOAL_FLOWERS_NEAR = 2,
     PATH_GOAL_COUNT
 } PathGoal;
 

--- a/include/path/path.h
+++ b/include/path/path.h
@@ -1,0 +1,31 @@
+#ifndef PATH_PATH_H
+#define PATH_PATH_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "hex.h"
+#include "params.h"
+#include "tile_core.h"
+
+typedef enum PathGoal {
+    PATH_GOAL_ENTRANCE = 0,
+    PATH_GOAL_COUNT
+} PathGoal;
+
+typedef struct PathVec2 {
+    float x;
+    float y;
+} PathVec2;
+
+bool path_init(const HexWorld *world, const Params *params);
+void path_shutdown(void);
+
+void path_update(const HexWorld *world, const Params *params, float dt_sec);
+
+void path_force_recompute(PathGoal goal);
+
+bool path_query_direction(PathGoal goal, TileId nid, PathVec2 *dir_world_out);
+
+#endif  // PATH_PATH_H

--- a/include/path/path.h
+++ b/include/path/path.h
@@ -11,6 +11,7 @@
 
 typedef enum PathGoal {
     PATH_GOAL_ENTRANCE = 0,
+    PATH_GOAL_UNLOAD = 1,
     PATH_GOAL_COUNT
 } PathGoal;
 

--- a/include/path/path_cost.h
+++ b/include/path/path_cost.h
@@ -1,0 +1,16 @@
+#ifndef PATH_PATH_COST_H
+#define PATH_PATH_COST_H
+
+#include <stddef.h>
+
+#include "tile_core.h"
+
+void path_cost_set_coeffs(float alpha_congestion, float gamma_hazard);
+void path_cost_set_ema_lambda(float lambda);
+void path_cost_set_dirty_threshold(float relative_eps);
+void path_cost_set_hazard(TileId nid, float penalty);
+void path_cost_add_crowd_samples(const TileId *tiles, const float *bees_per_sec, int count);
+void path_cost_mark_dirty(TileId nid);
+void path_cost_mark_many_dirty(const TileId *tiles, int count);
+
+#endif  // PATH_PATH_COST_H

--- a/include/path/path_debug.h
+++ b/include/path/path_debug.h
@@ -1,0 +1,14 @@
+#ifndef PATH_PATH_DEBUG_H
+#define PATH_PATH_DEBUG_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+void path_debug_begin_frame(void);
+bool path_debug_add_line(float x0, float y0, float x1, float y1, uint32_t color_rgba);
+const float *path_debug_lines_xy(void);
+const uint32_t *path_debug_lines_rgba(void);
+size_t path_debug_line_count(void);
+
+#endif  // PATH_PATH_DEBUG_H

--- a/include/path/path_fields.h
+++ b/include/path/path_fields.h
@@ -1,0 +1,14 @@
+#ifndef PATH_PATH_FIELDS_H
+#define PATH_PATH_FIELDS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "path/path.h"
+
+const float *path_field_dist(PathGoal goal);
+const uint8_t *path_field_next(PathGoal goal);
+uint32_t path_field_stamp(PathGoal goal);
+size_t path_field_tile_count(void);
+
+#endif  // PATH_PATH_FIELDS_H

--- a/include/path/path_scheduler.h
+++ b/include/path/path_scheduler.h
@@ -14,5 +14,7 @@ size_t path_sched_get_last_relaxed(PathGoal goal);
 bool path_sched_is_building(PathGoal goal);
 uint32_t path_sched_get_stamp(PathGoal goal);
 void path_sched_force_full_recompute(PathGoal goal);
+size_t path_sched_get_dirty_queue_len(void);
+size_t path_sched_get_dirty_processed_last_build(PathGoal goal);
 
 #endif  // PATH_PATH_SCHEDULER_H

--- a/include/path/path_scheduler.h
+++ b/include/path/path_scheduler.h
@@ -1,0 +1,18 @@
+#ifndef PATH_PATH_SCHEDULER_H
+#define PATH_PATH_SCHEDULER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "path/path.h"
+
+void path_sched_set_budget_ms(float per_frame_ms);
+void path_sched_set_cadence(PathGoal goal, float Hz);
+float path_sched_get_last_build_ms(PathGoal goal);
+size_t path_sched_get_last_relaxed(PathGoal goal);
+bool path_sched_is_building(PathGoal goal);
+uint32_t path_sched_get_stamp(PathGoal goal);
+void path_sched_force_full_recompute(PathGoal goal);
+
+#endif  // PATH_PATH_SCHEDULER_H

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -9,6 +9,7 @@
 #include "render.h"
 #include "sim.h"
 #include "ui.h"
+#include "bee.h"
 
 #include "util/log.h"
 
@@ -570,7 +571,11 @@ void app_frame(void) {
             if (sim_get_bee_info(g_sim, g_selected_bee_index, &info)) {
                 ui_set_selected_bee(&info, true);
                 if (info.path_valid) {
-                    const uint32_t debug_color = 0xFF0000FFu;
+                    uint32_t debug_color = 0xFF0000FFu;
+                    if ((info.mode == BEE_MODE_RETURNING || info.mode == BEE_MODE_ENTERING) &&
+                        info.path_valid == 2u) {
+                        debug_color = 0x33AAFFFFu;
+                    }
                     const float eps = 1e-3f;
                     bool distinct_waypoint = info.path_has_waypoint &&
                                              (fabsf(info.path_waypoint_x - info.path_final_x) > eps ||

--- a/src/path/path_core.c
+++ b/src/path/path_core.c
@@ -1,0 +1,283 @@
+#include "path/path.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "path/path_internal.h"
+#include "path/path_scheduler.h"
+#include "util/log.h"
+
+static const int kAxialDirs[6][2] = {
+    {1, 0},
+    {1, -1},
+    {0, -1},
+    {-1, 0},
+    {-1, 1},
+    {0, 1},
+};
+
+static const HexWorld *g_world = NULL;
+static size_t g_tile_count = 0;
+static int32_t *g_neighbors = NULL;
+static TileId *g_goal_entrance = NULL;
+static size_t g_goal_entrance_count = 0;
+static float g_dir_world[6][2] = {{0}};
+static bool g_path_initialized = false;
+
+static void clear_core_storage(void) {
+    free(g_neighbors);
+    g_neighbors = NULL;
+    free(g_goal_entrance);
+    g_goal_entrance = NULL;
+    g_tile_count = 0;
+    g_goal_entrance_count = 0;
+    g_world = NULL;
+    memset(g_dir_world, 0, sizeof(g_dir_world));
+}
+
+static bool compute_direction_table(const HexWorld *world) {
+    if (!world) {
+        return false;
+    }
+    float base_x = 0.0f;
+    float base_y = 0.0f;
+    hex_world_axial_to_world(world, 0, 0, &base_x, &base_y);
+    for (int dir = 0; dir < 6; ++dir) {
+        int dq = kAxialDirs[dir][0];
+        int dr = kAxialDirs[dir][1];
+        float neighbor_x = 0.0f;
+        float neighbor_y = 0.0f;
+        hex_world_axial_to_world(world, dq, dr, &neighbor_x, &neighbor_y);
+        float dx = neighbor_x - base_x;
+        float dy = neighbor_y - base_y;
+        float len = sqrtf(dx * dx + dy * dy);
+        if (len > 0.0f) {
+            dx /= len;
+            dy /= len;
+        } else {
+            dx = 0.0f;
+            dy = 0.0f;
+        }
+        g_dir_world[dir][0] = dx;
+        g_dir_world[dir][1] = dy;
+    }
+    return true;
+}
+
+static bool build_neighbors(const HexWorld *world) {
+    size_t tile_count = hex_world_tile_count(world);
+    if (tile_count == 0) {
+        return true;
+    }
+    int32_t *neighbors = (int32_t *)malloc(tile_count * 6u * sizeof(int32_t));
+    if (!neighbors) {
+        LOG_ERROR("path: failed to allocate neighbor table (%zu tiles)", tile_count);
+        return false;
+    }
+    for (size_t i = 0; i < tile_count * 6u; ++i) {
+        neighbors[i] = -1;
+    }
+
+    for (size_t index = 0; index < tile_count; ++index) {
+        if (!hex_world_tile_passable(world, index)) {
+            continue;
+        }
+        int q = 0;
+        int r = 0;
+        if (!hex_world_index_to_axial(world, index, &q, &r)) {
+            continue;
+        }
+        for (int dir = 0; dir < 6; ++dir) {
+            int nq = q + kAxialDirs[dir][0];
+            int nr = r + kAxialDirs[dir][1];
+            if (!hex_world_in_bounds(world, nq, nr)) {
+                continue;
+            }
+            size_t neighbor_index = hex_world_index(world, nq, nr);
+            if (!hex_world_tile_passable(world, neighbor_index)) {
+                continue;
+            }
+            neighbors[index * 6u + (size_t)dir] = (int32_t)neighbor_index;
+        }
+    }
+
+    g_neighbors = neighbors;
+    return true;
+}
+
+static bool build_entrance_goals(const HexWorld *world) {
+    size_t tile_count = hex_world_tile_count(world);
+    if (tile_count == 0) {
+        g_goal_entrance_count = 0;
+        return false;
+    }
+    TileId *goals = (TileId *)malloc(tile_count * sizeof(TileId));
+    if (!goals) {
+        LOG_ERROR("path: failed to allocate goal buffer (%zu tiles)", tile_count);
+        return false;
+    }
+    size_t count = 0;
+    for (size_t index = 0; index < tile_count; ++index) {
+        const HexTile *tile = &world->tiles[index];
+        if (tile->terrain == HEX_TERRAIN_HIVE_ENTRANCE) {
+            goals[count++] = index;
+        }
+    }
+    if (count == 0) {
+        LOG_ERROR("path: no entrance tiles found; path field unavailable");
+        free(goals);
+        return false;
+    }
+    g_goal_entrance = goals;
+    g_goal_entrance_count = count;
+    return true;
+}
+
+const float *path_core_direction_world(uint8_t dir_index) {
+    if (dir_index >= 6u) {
+        return NULL;
+    }
+    return g_dir_world[dir_index];
+}
+
+bool path_init(const HexWorld *world, const Params *params) {
+    (void)params;
+    if (!world) {
+        LOG_ERROR("path: init requires valid world");
+        return false;
+    }
+
+    path_shutdown();
+
+    g_world = world;
+    g_tile_count = hex_world_tile_count(world);
+
+    path_sched_reset_state();
+
+    if (!compute_direction_table(world)) {
+        LOG_ERROR("path: failed to compute direction vectors");
+        path_shutdown();
+        return false;
+    }
+
+    if (!build_neighbors(world)) {
+        path_shutdown();
+        return false;
+    }
+
+    if (!build_entrance_goals(world)) {
+        path_shutdown();
+        return false;
+    }
+
+    if (!path_fields_init_storage(g_tile_count)) {
+        path_shutdown();
+        return false;
+    }
+
+    if (!path_fields_start_build(PATH_GOAL_ENTRANCE,
+                                 world,
+                                 g_neighbors,
+                                 g_goal_entrance,
+                                 g_goal_entrance_count)) {
+        LOG_ERROR("path: failed to start entrance field build");
+        path_shutdown();
+        return false;
+    }
+
+    bool finished = false;
+    while (!finished) {
+        if (!path_fields_step(PATH_GOAL_ENTRANCE, 1000000.0, NULL, NULL, &finished)) {
+            LOG_ERROR("path: failed while building entrance field");
+            path_shutdown();
+            return false;
+        }
+    }
+
+    path_sched_set_goal_data(PATH_GOAL_ENTRANCE,
+                             world,
+                             g_neighbors,
+                             g_goal_entrance,
+                             g_goal_entrance_count,
+                             g_tile_count);
+
+    if (!path_debug_init()) {
+        LOG_WARN("path: debug overlay initialization failed");
+    }
+    path_debug_reset_overlay();
+    const uint8_t *next = path_field_next(PATH_GOAL_ENTRANCE);
+    size_t tile_count = path_field_tile_count();
+    if (next && tile_count == g_tile_count) {
+        path_debug_build_overlay(world, PATH_GOAL_ENTRANCE, next, tile_count);
+    }
+
+    g_path_initialized = true;
+    LOG_INFO("path: entrance field built (tiles=%zu goals=%zu)", g_tile_count, g_goal_entrance_count);
+    return true;
+}
+
+void path_shutdown(void) {
+    if (!g_path_initialized) {
+        path_debug_reset_overlay();
+    }
+    path_debug_shutdown();
+    path_sched_shutdown_state();
+    path_fields_shutdown_storage();
+    clear_core_storage();
+    g_path_initialized = false;
+}
+
+void path_update(const HexWorld *world, const Params *params, float dt_sec) {
+    (void)world;
+    (void)params;
+    if (!g_path_initialized || !g_world) {
+        return;
+    }
+
+    bool swapped = false;
+    if (!path_sched_update(dt_sec, &swapped)) {
+        return;
+    }
+    if (swapped) {
+        const uint8_t *next = path_field_next(PATH_GOAL_ENTRANCE);
+        size_t tile_count = path_field_tile_count();
+        if (next && tile_count == g_tile_count) {
+            path_debug_reset_overlay();
+            if (!path_debug_build_overlay(g_world, PATH_GOAL_ENTRANCE, next, tile_count)) {
+                path_debug_reset_overlay();
+            }
+        }
+    }
+}
+
+void path_force_recompute(PathGoal goal) {
+    if (!g_path_initialized || goal != PATH_GOAL_ENTRANCE) {
+        return;
+    }
+    path_sched_force_full_recompute(goal);
+}
+
+bool path_query_direction(PathGoal goal, TileId nid, PathVec2 *dir_world_out) {
+    if (!dir_world_out || goal != PATH_GOAL_ENTRANCE || !g_world) {
+        return false;
+    }
+    if (nid >= g_tile_count) {
+        return false;
+    }
+    const uint8_t *next = path_field_next(goal);
+    if (!next) {
+        return false;
+    }
+    uint8_t dir = next[nid];
+    if (dir >= 6u) {
+        return false;
+    }
+    const float *vec = g_dir_world[dir];
+    dir_world_out->x = vec[0];
+    dir_world_out->y = vec[1];
+    return true;
+}
+

--- a/src/path/path_cost.c
+++ b/src/path/path_cost.c
@@ -1,0 +1,356 @@
+#include "path/path_cost.h"
+
+#include <math.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hex.h"
+#include "path/path_internal.h"
+#include "util/log.h"
+
+static const float kMinEffCost = 1e-3f;
+static const float kMaxEffCost = 1e6f;
+
+static const HexWorld *g_cost_world = NULL;
+static size_t g_tile_count = 0u;
+static float *g_base_cost = NULL;
+static float *g_flow_capacity = NULL;
+static float *g_crowd_density = NULL;
+static float *g_hazard_penalty = NULL;
+static float *g_eff_cost = NULL;
+static uint8_t *g_dirty_flags = NULL;
+static TileId *g_dirty_list = NULL;
+static size_t g_dirty_count = 0u;
+static size_t g_dirty_capacity = 0u;
+static bool g_initialized = false;
+
+static float g_alpha_congestion = 1.0f;
+static float g_gamma_hazard = 2.0f;
+static float g_ema_lambda = 0.2f;
+static float g_dirty_epsilon = 0.1f;
+
+static inline float clamp_cost(float value) {
+    if (value < kMinEffCost) {
+        return kMinEffCost;
+    }
+    if (value > kMaxEffCost) {
+        return kMaxEffCost;
+    }
+    return value;
+}
+
+static bool ensure_dirty_capacity(size_t needed) {
+    if (g_dirty_capacity >= needed) {
+        return true;
+    }
+    size_t new_capacity = g_dirty_capacity ? g_dirty_capacity : 256u;
+    while (new_capacity < needed) {
+        new_capacity *= 2u;
+    }
+    TileId *new_list = (TileId *)realloc(g_dirty_list, new_capacity * sizeof(TileId));
+    if (!new_list) {
+        LOG_ERROR("path_cost: failed to grow dirty queue (capacity=%zu)", new_capacity);
+        return false;
+    }
+    g_dirty_list = new_list;
+    g_dirty_capacity = new_capacity;
+    return true;
+}
+
+static void clear_dirty_queue(void) {
+    g_dirty_count = 0u;
+}
+
+static void enqueue_dirty(TileId nid) {
+    if (!g_initialized || nid >= (TileId)g_tile_count) {
+        return;
+    }
+    if (g_dirty_flags[nid]) {
+        return;
+    }
+    if (!ensure_dirty_capacity(g_dirty_count + 1u)) {
+        return;
+    }
+    g_dirty_list[g_dirty_count++] = nid;
+    g_dirty_flags[nid] = 1u;
+}
+
+static float compute_congestion_penalty(size_t index) {
+    float capacity = g_flow_capacity ? g_flow_capacity[index] : 1.0f;
+    if (capacity <= 1e-4f) {
+        capacity = 1.0f;
+    }
+    float density = g_crowd_density ? g_crowd_density[index] : 0.0f;
+    float rho = density / capacity;
+    if (rho <= 1.0f) {
+        return 0.0f;
+    }
+    float diff = rho - 1.0f;
+    return diff * diff;
+}
+
+static float compute_eff_cost(size_t index) {
+    float base = g_base_cost ? g_base_cost[index] : 1.0f;
+    if (!g_cost_world || index >= g_tile_count) {
+        return clamp_cost(base);
+    }
+    const HexTile *tile = &g_cost_world->tiles[index];
+    if (!tile->passable) {
+        return kMaxEffCost;
+    }
+    float hazard = g_hazard_penalty ? g_hazard_penalty[index] : 0.0f;
+    float congestion = compute_congestion_penalty(index);
+    float eff = base + g_alpha_congestion * congestion + g_gamma_hazard * hazard;
+    if (!isfinite(eff)) {
+        eff = kMaxEffCost;
+    }
+    return clamp_cost(eff);
+}
+
+static void update_eff_cost(size_t index, bool force_dirty) {
+    if (!g_eff_cost || index >= g_tile_count) {
+        return;
+    }
+    float old_cost = g_eff_cost[index];
+    float new_cost = compute_eff_cost(index);
+    g_eff_cost[index] = new_cost;
+    if (!force_dirty) {
+        float delta = fabsf(new_cost - old_cost);
+        float ref = fabsf(old_cost);
+        if (ref < 1e-4f) {
+            ref = 1e-4f;
+        }
+        if (delta < ref * g_dirty_epsilon) {
+            return;
+        }
+    }
+    enqueue_dirty((TileId)index);
+}
+
+static void recompute_all_costs(bool force_dirty) {
+    if (!g_initialized || !g_eff_cost) {
+        return;
+    }
+    for (size_t i = 0; i < g_tile_count; ++i) {
+        update_eff_cost(i, force_dirty);
+    }
+}
+
+bool path_cost_init(const HexWorld *world) {
+    path_cost_shutdown();
+    if (!world) {
+        return false;
+    }
+    size_t tile_count = hex_world_tile_count(world);
+    if (tile_count == 0) {
+        g_cost_world = world;
+        g_initialized = true;
+        return true;
+    }
+
+    g_base_cost = (float *)malloc(tile_count * sizeof(float));
+    g_flow_capacity = (float *)malloc(tile_count * sizeof(float));
+    g_crowd_density = (float *)calloc(tile_count, sizeof(float));
+    g_hazard_penalty = (float *)calloc(tile_count, sizeof(float));
+    g_eff_cost = (float *)malloc(tile_count * sizeof(float));
+    g_dirty_flags = (uint8_t *)calloc(tile_count, sizeof(uint8_t));
+
+    if (!g_base_cost || !g_flow_capacity || !g_crowd_density || !g_hazard_penalty || !g_eff_cost ||
+        !g_dirty_flags) {
+        LOG_ERROR("path_cost: failed to allocate cost buffers (%zu tiles)", tile_count);
+        path_cost_shutdown();
+        return false;
+    }
+
+    for (size_t i = 0; i < tile_count; ++i) {
+        const HexTile *tile = &world->tiles[i];
+        float base = tile->base_cost;
+        if (!tile->passable) {
+            base = kMaxEffCost;
+        }
+        if (!(base > 0.0f)) {
+            base = 1.0f;
+        }
+        g_base_cost[i] = clamp_cost(base);
+        float capacity = tile->flow_capacity;
+        if (!(capacity > 0.0f)) {
+            capacity = 1.0f;
+        }
+        g_flow_capacity[i] = capacity;
+        g_eff_cost[i] = compute_eff_cost(i);
+    }
+
+    g_cost_world = world;
+    g_tile_count = tile_count;
+    g_initialized = true;
+    clear_dirty_queue();
+    return true;
+}
+
+void path_cost_shutdown(void) {
+    free(g_base_cost);
+    free(g_flow_capacity);
+    free(g_crowd_density);
+    free(g_hazard_penalty);
+    free(g_eff_cost);
+    free(g_dirty_flags);
+    free(g_dirty_list);
+
+    g_base_cost = NULL;
+    g_flow_capacity = NULL;
+    g_crowd_density = NULL;
+    g_hazard_penalty = NULL;
+    g_eff_cost = NULL;
+    g_dirty_flags = NULL;
+    g_dirty_list = NULL;
+    g_dirty_capacity = 0u;
+    g_dirty_count = 0u;
+    g_cost_world = NULL;
+    g_tile_count = 0u;
+    g_initialized = false;
+}
+
+const float *path_cost_eff_costs(void) {
+    return g_eff_cost;
+}
+
+size_t path_cost_tile_count(void) {
+    return g_tile_count;
+}
+
+size_t path_cost_dirty_count(void) {
+    return g_dirty_count;
+}
+
+size_t path_cost_consume_dirty(TileId *out, size_t max_tiles) {
+    if (!g_initialized || g_dirty_count == 0u || !out || max_tiles == 0u) {
+        return 0u;
+    }
+    size_t count = g_dirty_count;
+    if (count > max_tiles) {
+        count = max_tiles;
+    }
+    memcpy(out, g_dirty_list, count * sizeof(TileId));
+    for (size_t i = 0; i < count; ++i) {
+        TileId nid = out[i];
+        if ((size_t)nid < g_tile_count) {
+            g_dirty_flags[nid] = 0u;
+        }
+    }
+    if (count < g_dirty_count) {
+        size_t remain = g_dirty_count - count;
+        memmove(g_dirty_list, g_dirty_list + count, remain * sizeof(TileId));
+        g_dirty_count = remain;
+    } else {
+        g_dirty_count = 0u;
+    }
+    return count;
+}
+
+void path_cost_requeue_tiles(const TileId *tiles, size_t count) {
+    if (!tiles) {
+        return;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        path_cost_mark_dirty(tiles[i]);
+    }
+}
+
+void path_cost_set_coeffs(float alpha_congestion, float gamma_hazard) {
+    if (alpha_congestion < 0.0f) {
+        alpha_congestion = 0.0f;
+    }
+    if (gamma_hazard < 0.0f) {
+        gamma_hazard = 0.0f;
+    }
+    if (fabsf(g_alpha_congestion - alpha_congestion) < 1e-6f &&
+        fabsf(g_gamma_hazard - gamma_hazard) < 1e-6f) {
+        return;
+    }
+    g_alpha_congestion = alpha_congestion;
+    g_gamma_hazard = gamma_hazard;
+    recompute_all_costs(false);
+}
+
+void path_cost_set_ema_lambda(float lambda) {
+    if (lambda < 0.0f) {
+        lambda = 0.0f;
+    }
+    if (lambda > 1.0f) {
+        lambda = 1.0f;
+    }
+    g_ema_lambda = lambda;
+}
+
+void path_cost_set_dirty_threshold(float relative_eps) {
+    if (relative_eps < 0.0f) {
+        relative_eps = 0.0f;
+    }
+    g_dirty_epsilon = relative_eps;
+}
+
+void path_cost_set_hazard(TileId nid, float penalty) {
+    if (!g_initialized || !g_hazard_penalty || nid < 0 || (size_t)nid >= g_tile_count) {
+        return;
+    }
+    if (penalty < 0.0f) {
+        penalty = 0.0f;
+    }
+    float old_penalty = g_hazard_penalty[nid];
+    if (fabsf(old_penalty - penalty) < 1e-6f) {
+        return;
+    }
+    g_hazard_penalty[nid] = penalty;
+    update_eff_cost((size_t)nid, false);
+}
+
+void path_cost_add_crowd_samples(const TileId *tiles, const float *bees_per_sec, int count) {
+    if (!g_initialized || !g_crowd_density || !tiles || !bees_per_sec || count <= 0) {
+        return;
+    }
+    float lambda = g_ema_lambda;
+    for (int i = 0; i < count; ++i) {
+        TileId nid = tiles[i];
+        if (nid < 0 || (size_t)nid >= g_tile_count) {
+            continue;
+        }
+        float sample = bees_per_sec[i];
+        if (sample < 0.0f) {
+            sample = 0.0f;
+        }
+        float prev = g_crowd_density[nid];
+        float updated = sample;
+        if (lambda <= 0.0f) {
+            updated = prev;
+        } else if (lambda >= 1.0f) {
+            updated = sample;
+        } else {
+            updated = prev + lambda * (sample - prev);
+        }
+        if (fabsf(updated - prev) < 1e-6f) {
+            continue;
+        }
+        g_crowd_density[nid] = updated;
+        update_eff_cost((size_t)nid, false);
+    }
+}
+
+void path_cost_mark_dirty(TileId nid) {
+    if (!g_initialized || nid < 0 || (size_t)nid >= g_tile_count) {
+        return;
+    }
+    enqueue_dirty(nid);
+}
+
+void path_cost_mark_many_dirty(const TileId *tiles, int count) {
+    if (!tiles || count <= 0) {
+        return;
+    }
+    for (int i = 0; i < count; ++i) {
+        path_cost_mark_dirty(tiles[i]);
+    }
+}
+

--- a/src/path/path_debug.c
+++ b/src/path/path_debug.c
@@ -1,0 +1,175 @@
+#include "path/path_debug.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "path/path_internal.h"
+#include "util/log.h"
+
+static float *g_overlay_lines_xy = NULL;
+static uint32_t *g_overlay_line_rgba = NULL;
+static size_t g_overlay_line_count = 0;
+
+static float *g_frame_lines_xy = NULL;
+static uint32_t *g_frame_line_rgba = NULL;
+static size_t g_frame_line_capacity = 0;
+static size_t g_frame_line_count = 0;
+
+static bool g_debug_initialized = false;
+
+bool path_debug_init(void) {
+    g_debug_initialized = true;
+    return true;
+}
+
+void path_debug_shutdown(void) {
+    free(g_overlay_lines_xy);
+    free(g_overlay_line_rgba);
+    free(g_frame_lines_xy);
+    free(g_frame_line_rgba);
+    g_overlay_lines_xy = NULL;
+    g_overlay_line_rgba = NULL;
+    g_frame_lines_xy = NULL;
+    g_frame_line_rgba = NULL;
+    g_overlay_line_count = 0;
+    g_frame_line_capacity = 0;
+    g_frame_line_count = 0;
+    g_debug_initialized = false;
+}
+
+void path_debug_reset_overlay(void) {
+    g_overlay_line_count = 0;
+}
+
+static bool ensure_frame_capacity(size_t line_capacity) {
+    if (line_capacity <= g_frame_line_capacity) {
+        return true;
+    }
+    size_t new_capacity = g_frame_line_capacity ? g_frame_line_capacity : 128u;
+    while (new_capacity < line_capacity) {
+        new_capacity *= 2u;
+    }
+    float *new_xy = (float *)realloc(g_frame_lines_xy, new_capacity * 4u * sizeof(float));
+    uint32_t *new_rgba = (uint32_t *)realloc(g_frame_line_rgba, new_capacity * sizeof(uint32_t));
+    if (!new_xy || !new_rgba) {
+        free(new_xy);
+        free(new_rgba);
+        return false;
+    }
+    g_frame_lines_xy = new_xy;
+    g_frame_line_rgba = new_rgba;
+    g_frame_line_capacity = new_capacity;
+    return true;
+}
+
+bool path_debug_build_overlay(const HexWorld *world,
+                              PathGoal goal,
+                              const uint8_t *next,
+                              size_t tile_count) {
+    if (!g_debug_initialized) {
+        if (!path_debug_init()) {
+            return false;
+        }
+    }
+    if (!world || !next || goal != PATH_GOAL_ENTRANCE) {
+        g_overlay_line_count = 0;
+        return false;
+    }
+    const float *centers = hex_world_centers_xy(world);
+    float cell_radius = hex_world_cell_radius(world);
+    if (!centers || cell_radius <= 0.0f) {
+        g_overlay_line_count = 0;
+        return false;
+    }
+
+    size_t arrow_count = 0;
+    for (size_t i = 0; i < tile_count; ++i) {
+        if (next[i] < 6u) {
+            ++arrow_count;
+        }
+    }
+
+    if (arrow_count == 0) {
+        g_overlay_line_count = 0;
+        return true;
+    }
+
+    float *new_xy = (float *)realloc(g_overlay_lines_xy, arrow_count * 4u * sizeof(float));
+    uint32_t *new_rgba = (uint32_t *)realloc(g_overlay_line_rgba, arrow_count * sizeof(uint32_t));
+    if (!new_xy || !new_rgba) {
+        free(new_xy);
+        free(new_rgba);
+        LOG_WARN("path_debug: failed to allocate overlay buffer (%zu arrows)", arrow_count);
+        g_overlay_line_count = 0;
+        return false;
+    }
+    g_overlay_lines_xy = new_xy;
+    g_overlay_line_rgba = new_rgba;
+
+    const uint32_t arrow_color = 0x33FF66FFu;
+    const float arrow_scale = cell_radius * 0.6f;
+
+    size_t arrow_index = 0;
+    for (size_t i = 0; i < tile_count; ++i) {
+        uint8_t dir = next[i];
+        if (dir >= 6u) {
+            continue;
+        }
+        const float *dir_world = path_core_direction_world(dir);
+        float cx = centers[i * 2u + 0u];
+        float cy = centers[i * 2u + 1u];
+        float dx = dir_world ? dir_world[0] : 0.0f;
+        float dy = dir_world ? dir_world[1] : 0.0f;
+        float ex = cx + dx * arrow_scale;
+        float ey = cy + dy * arrow_scale;
+        size_t base = arrow_index * 4u;
+        g_overlay_lines_xy[base + 0u] = cx;
+        g_overlay_lines_xy[base + 1u] = cy;
+        g_overlay_lines_xy[base + 2u] = ex;
+        g_overlay_lines_xy[base + 3u] = ey;
+        g_overlay_line_rgba[arrow_index] = arrow_color;
+        ++arrow_index;
+    }
+
+    g_overlay_line_count = arrow_index;
+    return true;
+}
+
+void path_debug_begin_frame(void) {
+    if (!ensure_frame_capacity(g_overlay_line_count)) {
+        g_frame_line_count = 0;
+        return;
+    }
+    if (g_overlay_line_count > 0 && g_overlay_lines_xy && g_overlay_line_rgba) {
+        memcpy(g_frame_lines_xy, g_overlay_lines_xy, g_overlay_line_count * 4u * sizeof(float));
+        memcpy(g_frame_line_rgba, g_overlay_line_rgba, g_overlay_line_count * sizeof(uint32_t));
+    }
+    g_frame_line_count = g_overlay_line_count;
+}
+
+bool path_debug_add_line(float x0, float y0, float x1, float y1, uint32_t color_rgba) {
+    if (!ensure_frame_capacity(g_frame_line_count + 1u)) {
+        return false;
+    }
+    size_t base = g_frame_line_count * 4u;
+    g_frame_lines_xy[base + 0u] = x0;
+    g_frame_lines_xy[base + 1u] = y0;
+    g_frame_lines_xy[base + 2u] = x1;
+    g_frame_lines_xy[base + 3u] = y1;
+    g_frame_line_rgba[g_frame_line_count] = color_rgba;
+    g_frame_line_count += 1u;
+    return true;
+}
+
+const float *path_debug_lines_xy(void) {
+    return (g_frame_line_count > 0) ? g_frame_lines_xy : NULL;
+}
+
+const uint32_t *path_debug_lines_rgba(void) {
+    return (g_frame_line_count > 0) ? g_frame_line_rgba : NULL;
+}
+
+size_t path_debug_line_count(void) {
+    return g_frame_line_count;
+}
+

--- a/src/path/path_fields.c
+++ b/src/path/path_fields.c
@@ -1,0 +1,409 @@
+#include "path/path_fields.h"
+
+#include <float.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "path/path_internal.h"
+#include "util/log.h"
+
+typedef struct PathNode {
+    TileId id;
+    float dist;
+} PathNode;
+
+typedef struct PathHeap {
+    PathNode *data;
+    size_t size;
+    size_t capacity;
+} PathHeap;
+
+typedef struct PathFieldBuildState {
+    PathHeap heap;
+    float *dist;
+    uint8_t *next;
+    const int32_t *neighbors;
+    const TileId *goals;
+    size_t goal_count;
+    bool in_progress;
+} PathFieldBuildState;
+
+typedef struct PathFieldState {
+    float *dist[2];
+    uint8_t *next[2];
+    size_t tile_count;
+    int active_index;
+    int build_index;
+    uint32_t stamp;
+    PathFieldBuildState entrance;
+} PathFieldState;
+
+static PathFieldState g_field_state = {0};
+
+static const float kInf = FLT_MAX / 4.0f;
+
+static double clock_now_ms(void) {
+    return (double)clock() * (1000.0 / (double)CLOCKS_PER_SEC);
+}
+
+static bool heap_reserve(PathHeap *heap, size_t capacity) {
+    if (!heap) {
+        return false;
+    }
+    if (capacity <= heap->capacity) {
+        return true;
+    }
+    size_t new_capacity = heap->capacity ? heap->capacity : 64u;
+    while (new_capacity < capacity) {
+        new_capacity *= 2u;
+    }
+    PathNode *new_data = (PathNode *)realloc(heap->data, new_capacity * sizeof(PathNode));
+    if (!new_data) {
+        return false;
+    }
+    heap->data = new_data;
+    heap->capacity = new_capacity;
+    return true;
+}
+
+static void heap_clear(PathHeap *heap) {
+    if (heap) {
+        heap->size = 0;
+    }
+}
+
+static void heap_swap(PathNode *a, PathNode *b) {
+    PathNode tmp = *a;
+    *a = *b;
+    *b = tmp;
+}
+
+static bool heap_push(PathHeap *heap, TileId id, float dist) {
+    if (!heap) {
+        return false;
+    }
+    if (!heap_reserve(heap, heap->size + 1u)) {
+        return false;
+    }
+    size_t index = heap->size++;
+    heap->data[index].id = id;
+    heap->data[index].dist = dist;
+    while (index > 0) {
+        size_t parent = (index - 1u) / 2u;
+        if (heap->data[parent].dist <= heap->data[index].dist) {
+            break;
+        }
+        heap_swap(&heap->data[parent], &heap->data[index]);
+        index = parent;
+    }
+    return true;
+}
+
+static bool heap_pop(PathHeap *heap, PathNode *out_node) {
+    if (!heap || heap->size == 0) {
+        return false;
+    }
+    if (out_node) {
+        *out_node = heap->data[0];
+    }
+    heap->size -= 1u;
+    if (heap->size == 0) {
+        return true;
+    }
+    heap->data[0] = heap->data[heap->size];
+    size_t index = 0;
+    while (true) {
+        size_t left = index * 2u + 1u;
+        size_t right = left + 1u;
+        size_t smallest = index;
+        if (left < heap->size && heap->data[left].dist < heap->data[smallest].dist) {
+            smallest = left;
+        }
+        if (right < heap->size && heap->data[right].dist < heap->data[smallest].dist) {
+            smallest = right;
+        }
+        if (smallest == index) {
+            break;
+        }
+        heap_swap(&heap->data[index], &heap->data[smallest]);
+        index = smallest;
+    }
+    return true;
+}
+
+static uint8_t opposite_direction(uint8_t dir) {
+    static const uint8_t kOpposite[6] = {3, 4, 5, 0, 1, 2};
+    if (dir < 6u) {
+        return kOpposite[dir];
+    }
+    return 255u;
+}
+
+bool path_fields_init_storage(size_t tile_count) {
+    if (tile_count == 0) {
+        path_fields_shutdown_storage();
+        return true;
+    }
+    bool size_changed = (g_field_state.tile_count != tile_count) || !g_field_state.dist[0] ||
+                        !g_field_state.dist[1] || !g_field_state.next[0] || !g_field_state.next[1];
+    if (size_changed) {
+        float *dist0 = (float *)malloc(tile_count * sizeof(float));
+        float *dist1 = (float *)malloc(tile_count * sizeof(float));
+        uint8_t *next0 = (uint8_t *)malloc(tile_count * sizeof(uint8_t));
+        uint8_t *next1 = (uint8_t *)malloc(tile_count * sizeof(uint8_t));
+        if (!dist0 || !dist1 || !next0 || !next1) {
+            free(dist0);
+            free(dist1);
+            free(next0);
+            free(next1);
+            LOG_ERROR("path: failed to allocate field storage (%zu tiles)", tile_count);
+            return false;
+        }
+        free(g_field_state.dist[0]);
+        free(g_field_state.dist[1]);
+        free(g_field_state.next[0]);
+        free(g_field_state.next[1]);
+        g_field_state.dist[0] = dist0;
+        g_field_state.dist[1] = dist1;
+        g_field_state.next[0] = next0;
+        g_field_state.next[1] = next1;
+    }
+    g_field_state.tile_count = tile_count;
+    g_field_state.active_index = 0;
+    g_field_state.build_index = 1;
+    g_field_state.stamp = 0u;
+    g_field_state.entrance.in_progress = false;
+    g_field_state.entrance.dist = NULL;
+    g_field_state.entrance.next = NULL;
+    g_field_state.entrance.neighbors = NULL;
+    g_field_state.entrance.goals = NULL;
+    g_field_state.entrance.goal_count = 0u;
+    heap_clear(&g_field_state.entrance.heap);
+    return true;
+}
+
+void path_fields_shutdown_storage(void) {
+    free(g_field_state.dist[0]);
+    free(g_field_state.dist[1]);
+    free(g_field_state.next[0]);
+    free(g_field_state.next[1]);
+    g_field_state.dist[0] = NULL;
+    g_field_state.dist[1] = NULL;
+    g_field_state.next[0] = NULL;
+    g_field_state.next[1] = NULL;
+    g_field_state.tile_count = 0u;
+    g_field_state.active_index = 0;
+    g_field_state.build_index = 1;
+    g_field_state.stamp = 0u;
+    g_field_state.entrance.in_progress = false;
+    g_field_state.entrance.dist = NULL;
+    g_field_state.entrance.next = NULL;
+    g_field_state.entrance.neighbors = NULL;
+    g_field_state.entrance.goals = NULL;
+    g_field_state.entrance.goal_count = 0u;
+    free(g_field_state.entrance.heap.data);
+    g_field_state.entrance.heap.data = NULL;
+    g_field_state.entrance.heap.size = 0u;
+    g_field_state.entrance.heap.capacity = 0u;
+}
+
+bool path_fields_start_build(PathGoal goal,
+                             const HexWorld *world,
+                             const int32_t *neighbors,
+                             const TileId *goals,
+                             size_t goal_count) {
+    (void)world;
+    if (goal != PATH_GOAL_ENTRANCE) {
+        return false;
+    }
+    if (!neighbors || !goals || goal_count == 0) {
+        LOG_WARN("path: cannot build entrance field without goals");
+        return false;
+    }
+    if (g_field_state.tile_count == 0u) {
+        return false;
+    }
+    PathFieldBuildState *build = &g_field_state.entrance;
+    build->neighbors = neighbors;
+    build->goals = goals;
+    build->goal_count = goal_count;
+    build->dist = g_field_state.dist[g_field_state.build_index];
+    build->next = g_field_state.next[g_field_state.build_index];
+    if (!build->dist || !build->next) {
+        return false;
+    }
+    size_t tile_count = g_field_state.tile_count;
+    for (size_t i = 0; i < tile_count; ++i) {
+        build->dist[i] = kInf;
+    }
+    memset(build->next, 0xFF, tile_count * sizeof(uint8_t));
+    heap_clear(&build->heap);
+    if (!heap_reserve(&build->heap, goal_count)) {
+        LOG_ERROR("path: failed to reserve heap for entrance goals");
+        return false;
+    }
+    for (size_t i = 0; i < goal_count; ++i) {
+        TileId goal_id = goals[i];
+        if ((size_t)goal_id >= tile_count) {
+            continue;
+        }
+        build->dist[goal_id] = 0.0f;
+        build->next[goal_id] = 255u;
+        if (!heap_push(&build->heap, goal_id, 0.0f)) {
+            LOG_ERROR("path: failed to seed entrance heap");
+            heap_clear(&build->heap);
+            return false;
+        }
+    }
+    if (build->heap.size == 0u) {
+        LOG_WARN("path: entrance build has no valid seeds");
+        heap_clear(&build->heap);
+        return false;
+    }
+    build->in_progress = true;
+    return true;
+}
+
+bool path_fields_step(PathGoal goal,
+                      double time_budget_ms,
+                      size_t *out_relaxed,
+                      double *out_elapsed_ms,
+                      bool *out_finished) {
+    if (out_relaxed) {
+        *out_relaxed = 0u;
+    }
+    if (out_elapsed_ms) {
+        *out_elapsed_ms = 0.0;
+    }
+    if (out_finished) {
+        *out_finished = false;
+    }
+    if (goal != PATH_GOAL_ENTRANCE) {
+        return false;
+    }
+    PathFieldBuildState *build = &g_field_state.entrance;
+    if (!build->in_progress || !build->dist || !build->next || !build->neighbors) {
+        return false;
+    }
+    size_t tile_count = g_field_state.tile_count;
+    if (tile_count == 0u) {
+        build->in_progress = false;
+        return false;
+    }
+    double budget = time_budget_ms;
+    if (budget < 0.0) {
+        budget = 0.0;
+    }
+    bool check_time = (budget > 0.0);
+    double start_ms = clock_now_ms();
+    size_t relaxed = 0u;
+    while (build->heap.size > 0u) {
+        PathNode current;
+        if (!heap_pop(&build->heap, &current)) {
+            break;
+        }
+        if ((size_t)current.id >= tile_count) {
+            continue;
+        }
+        if (current.dist > build->dist[current.id]) {
+            continue;
+        }
+        const int32_t *nbrs = build->neighbors + (size_t)current.id * 6u;
+        for (uint8_t dir = 0; dir < 6u; ++dir) {
+            int32_t neighbor = nbrs[dir];
+            if (neighbor < 0) {
+                continue;
+            }
+            size_t v = (size_t)neighbor;
+            float alt = current.dist + 1.0f;
+            if (alt < build->dist[v]) {
+                build->dist[v] = alt;
+                build->next[v] = opposite_direction(dir);
+                if (!heap_push(&build->heap, (TileId)v, alt)) {
+                    LOG_ERROR("path: failed to push node during entrance build");
+                    path_fields_cancel_build(goal);
+                    return false;
+                }
+            }
+        }
+        ++relaxed;
+        if (!check_time) {
+            if (relaxed >= 1u) {
+                break;
+            }
+        } else {
+            double elapsed_now = clock_now_ms() - start_ms;
+            if (elapsed_now >= budget) {
+                break;
+            }
+        }
+    }
+    double elapsed_ms = clock_now_ms() - start_ms;
+    if (out_relaxed) {
+        *out_relaxed = relaxed;
+    }
+    if (out_elapsed_ms) {
+        *out_elapsed_ms = elapsed_ms;
+    }
+    if (build->heap.size == 0u) {
+        build->in_progress = false;
+        g_field_state.active_index = g_field_state.build_index;
+        g_field_state.build_index = g_field_state.active_index ^ 1;
+        ++g_field_state.stamp;
+        if (g_field_state.stamp == 0u) {
+            g_field_state.stamp = 1u;
+        }
+        build->dist = NULL;
+        build->next = NULL;
+        if (out_finished) {
+            *out_finished = true;
+        }
+    }
+    return true;
+}
+
+bool path_fields_is_building(PathGoal goal) {
+    if (goal != PATH_GOAL_ENTRANCE) {
+        return false;
+    }
+    return g_field_state.entrance.in_progress;
+}
+
+void path_fields_cancel_build(PathGoal goal) {
+    if (goal != PATH_GOAL_ENTRANCE) {
+        return;
+    }
+    PathFieldBuildState *build = &g_field_state.entrance;
+    build->in_progress = false;
+    build->dist = NULL;
+    build->next = NULL;
+    heap_clear(&build->heap);
+}
+
+const float *path_field_dist(PathGoal goal) {
+    if (goal != PATH_GOAL_ENTRANCE) {
+        return NULL;
+    }
+    return g_field_state.dist[g_field_state.active_index];
+}
+
+const uint8_t *path_field_next(PathGoal goal) {
+    if (goal != PATH_GOAL_ENTRANCE) {
+        return NULL;
+    }
+    return g_field_state.next[g_field_state.active_index];
+}
+
+uint32_t path_field_stamp(PathGoal goal) {
+    if (goal != PATH_GOAL_ENTRANCE) {
+        return 0u;
+    }
+    return g_field_state.stamp;
+}
+
+size_t path_field_tile_count(void) {
+    return g_field_state.tile_count;
+}

--- a/src/path/path_fields.c
+++ b/src/path/path_fields.c
@@ -312,8 +312,6 @@ bool path_fields_start_build(PathGoal goal,
     }
 
     if (dirty_tiles && dirty_count > 0u) {
-        const float *active_dist = goal_state->dist[goal_state->active_index];
-        const uint8_t *active_next = goal_state->next[goal_state->active_index];
         for (size_t i = 0; i < dirty_count; ++i) {
             TileId nid = dirty_tiles[i];
             if ((size_t)nid >= tile_count) {
@@ -322,17 +320,8 @@ bool path_fields_start_build(PathGoal goal,
             if (build->dist[nid] == 0.0f) {
                 continue;
             }
-            float seed_dist = (active_dist && (size_t)nid < tile_count) ? active_dist[nid] : kInf;
-            uint8_t seed_next = (active_next && (size_t)nid < tile_count) ? active_next[nid] : 255u;
-            if (seed_dist < kInf) {
-                build->dist[nid] = seed_dist;
-                build->next[nid] = seed_next;
-                if (!heap_push(&build->heap, nid, seed_dist)) {
-                    LOG_ERROR("path: failed to push dirty seed for goal %d", (int)goal);
-                    path_fields_cancel_build(goal);
-                    return false;
-                }
-            }
+            build->dist[nid] = kInf;
+            build->next[nid] = 255u;
         }
     }
 

--- a/src/path/path_internal.h
+++ b/src/path/path_internal.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "path/path.h"
+#include "path/path_cost.h"
 #include "path/path_debug.h"
 #include "path/path_fields.h"
 
@@ -16,7 +17,10 @@ bool path_fields_start_build(PathGoal goal,
                              const struct HexWorld *world,
                              const int32_t *neighbors,
                              const TileId *goals,
-                             size_t goal_count);
+                             size_t goal_count,
+                             const float *eff_cost,
+                             const TileId *dirty_tiles,
+                             size_t dirty_count);
 bool path_fields_step(PathGoal goal,
                       double time_budget_ms,
                       size_t *out_relaxed,
@@ -44,5 +48,13 @@ void path_sched_set_goal_data(PathGoal goal,
                               size_t goal_count,
                               size_t tile_count);
 bool path_sched_update(float dt_sec, bool *out_field_swapped);
+
+bool path_cost_init(const struct HexWorld *world);
+void path_cost_shutdown(void);
+const float *path_cost_eff_costs(void);
+size_t path_cost_tile_count(void);
+size_t path_cost_dirty_count(void);
+size_t path_cost_consume_dirty(TileId *out, size_t max_tiles);
+void path_cost_requeue_tiles(const TileId *tiles, size_t count);
 
 #endif  // PATH_PATH_INTERNAL_H

--- a/src/path/path_internal.h
+++ b/src/path/path_internal.h
@@ -47,7 +47,7 @@ void path_sched_set_goal_data(PathGoal goal,
                               const TileId *goals,
                               size_t goal_count,
                               size_t tile_count);
-bool path_sched_update(float dt_sec, bool *out_field_swapped);
+bool path_sched_update(float dt_sec, bool out_field_swapped[PATH_GOAL_COUNT]);
 
 bool path_cost_init(const struct HexWorld *world);
 void path_cost_shutdown(void);

--- a/src/path/path_internal.h
+++ b/src/path/path_internal.h
@@ -18,6 +18,7 @@ bool path_fields_start_build(PathGoal goal,
                              const int32_t *neighbors,
                              const TileId *goals,
                              size_t goal_count,
+                             const float *goal_seed_costs,
                              const float *eff_cost,
                              const TileId *dirty_tiles,
                              size_t dirty_count);
@@ -37,7 +38,8 @@ void path_debug_reset_overlay(void);
 bool path_debug_build_overlay(const struct HexWorld *world,
                               PathGoal goal,
                               const uint8_t *next,
-                              size_t tile_count);
+                              size_t tile_count,
+                              uint32_t color_rgba);
 
 void path_sched_reset_state(void);
 void path_sched_shutdown_state(void);
@@ -45,6 +47,7 @@ void path_sched_set_goal_data(PathGoal goal,
                               const struct HexWorld *world,
                               const int32_t *neighbors,
                               const TileId *goals,
+                              const float *goal_seed_costs,
                               size_t goal_count,
                               size_t tile_count);
 bool path_sched_update(float dt_sec, bool out_field_swapped[PATH_GOAL_COUNT]);

--- a/src/path/path_internal.h
+++ b/src/path/path_internal.h
@@ -1,0 +1,48 @@
+#ifndef PATH_PATH_INTERNAL_H
+#define PATH_PATH_INTERNAL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "path/path.h"
+#include "path/path_debug.h"
+#include "path/path_fields.h"
+
+struct HexWorld;
+
+bool path_fields_init_storage(size_t tile_count);
+void path_fields_shutdown_storage(void);
+bool path_fields_start_build(PathGoal goal,
+                             const struct HexWorld *world,
+                             const int32_t *neighbors,
+                             const TileId *goals,
+                             size_t goal_count);
+bool path_fields_step(PathGoal goal,
+                      double time_budget_ms,
+                      size_t *out_relaxed,
+                      double *out_elapsed_ms,
+                      bool *out_finished);
+bool path_fields_is_building(PathGoal goal);
+void path_fields_cancel_build(PathGoal goal);
+
+const float *path_core_direction_world(uint8_t dir_index);
+
+bool path_debug_init(void);
+void path_debug_shutdown(void);
+void path_debug_reset_overlay(void);
+bool path_debug_build_overlay(const struct HexWorld *world,
+                              PathGoal goal,
+                              const uint8_t *next,
+                              size_t tile_count);
+
+void path_sched_reset_state(void);
+void path_sched_shutdown_state(void);
+void path_sched_set_goal_data(PathGoal goal,
+                              const struct HexWorld *world,
+                              const int32_t *neighbors,
+                              const TileId *goals,
+                              size_t goal_count,
+                              size_t tile_count);
+bool path_sched_update(float dt_sec, bool *out_field_swapped);
+
+#endif  // PATH_PATH_INTERNAL_H

--- a/src/path/path_scheduler.c
+++ b/src/path/path_scheduler.c
@@ -1,0 +1,262 @@
+#include "path/path_scheduler.h"
+
+#include <stddef.h>
+
+#include "path/path_fields.h"
+#include "path/path_internal.h"
+#include "util/log.h"
+
+typedef struct PathSchedGoalState {
+    float cadence_hz;
+    double cadence_interval_ms;
+    double time_since_last_start_ms;
+    bool building;
+    bool pending_force;
+    bool has_data;
+    const HexWorld *world;
+    const int32_t *neighbors;
+    const TileId *goals;
+    size_t goal_count;
+    size_t tile_count;
+    size_t nodes_relaxed_accum;
+    double elapsed_ms_accum;
+    float last_build_ms;
+    size_t last_relaxed;
+} PathSchedGoalState;
+
+typedef struct PathSchedulerState {
+    float budget_ms;
+    PathSchedGoalState goals[PATH_GOAL_COUNT];
+} PathSchedulerState;
+
+static PathSchedulerState g_sched = {0};
+
+static const float kDefaultCadenceHz[PATH_GOAL_COUNT] = {10.0f};
+
+static inline double cadence_to_interval(float hz) {
+    return (hz > 0.0f) ? (1000.0 / (double)hz) : 0.0;
+}
+
+static PathSchedGoalState *get_goal_state(PathGoal goal) {
+    if (goal < 0 || goal >= PATH_GOAL_COUNT) {
+        return NULL;
+    }
+    return &g_sched.goals[goal];
+}
+
+void path_sched_reset_state(void) {
+    g_sched.budget_ms = 1.5f;
+    for (int i = 0; i < PATH_GOAL_COUNT; ++i) {
+        PathSchedGoalState *state = &g_sched.goals[i];
+        state->cadence_hz = (i < (int)(sizeof kDefaultCadenceHz / sizeof kDefaultCadenceHz[0]))
+                                ? kDefaultCadenceHz[i]
+                                : 0.0f;
+        state->cadence_interval_ms = cadence_to_interval(state->cadence_hz);
+        state->time_since_last_start_ms = 0.0;
+        state->building = false;
+        state->pending_force = false;
+        state->has_data = false;
+        state->world = NULL;
+        state->neighbors = NULL;
+        state->goals = NULL;
+        state->goal_count = 0u;
+        state->tile_count = 0u;
+        state->nodes_relaxed_accum = 0u;
+        state->elapsed_ms_accum = 0.0;
+        state->last_build_ms = 0.0f;
+        state->last_relaxed = 0u;
+    }
+}
+
+void path_sched_shutdown_state(void) {
+    for (int i = 0; i < PATH_GOAL_COUNT; ++i) {
+        if (path_fields_is_building((PathGoal)i)) {
+            path_fields_cancel_build((PathGoal)i);
+        }
+    }
+    path_sched_reset_state();
+}
+
+void path_sched_set_goal_data(PathGoal goal,
+                              const HexWorld *world,
+                              const int32_t *neighbors,
+                              const TileId *goals,
+                              size_t goal_count,
+                              size_t tile_count) {
+    PathSchedGoalState *state = get_goal_state(goal);
+    if (!state) {
+        return;
+    }
+    if (path_fields_is_building(goal)) {
+        path_fields_cancel_build(goal);
+    }
+    state->world = world;
+    state->neighbors = neighbors;
+    state->goals = goals;
+    state->goal_count = goal_count;
+    state->tile_count = tile_count;
+    state->has_data = (world && neighbors && goals && goal_count > 0u && tile_count > 0u);
+    state->building = false;
+    state->pending_force = false;
+    state->nodes_relaxed_accum = 0u;
+    state->elapsed_ms_accum = 0.0;
+    state->time_since_last_start_ms = 0.0;
+}
+
+bool path_sched_update(float dt_sec, bool *out_field_swapped) {
+    if (out_field_swapped) {
+        *out_field_swapped = false;
+    }
+    PathSchedGoalState *state = get_goal_state(PATH_GOAL_ENTRANCE);
+    if (!state) {
+        return false;
+    }
+    double dt_ms = (dt_sec > 0.0f) ? (double)dt_sec * 1000.0 : 0.0;
+    if (!state->building) {
+        state->time_since_last_start_ms += dt_ms;
+    }
+
+    bool swapped = false;
+    if (state->building) {
+        size_t relaxed = 0u;
+        double step_ms = 0.0;
+        bool finished = false;
+        if (path_fields_step(PATH_GOAL_ENTRANCE, g_sched.budget_ms, &relaxed, &step_ms, &finished)) {
+            state->nodes_relaxed_accum += relaxed;
+            state->elapsed_ms_accum += step_ms;
+            if (finished) {
+                state->last_relaxed = state->nodes_relaxed_accum;
+                state->last_build_ms = (float)state->elapsed_ms_accum;
+                state->nodes_relaxed_accum = 0u;
+                state->elapsed_ms_accum = 0.0;
+                state->building = false;
+                state->time_since_last_start_ms = 0.0;
+                swapped = true;
+            }
+        } else {
+            LOG_WARN("path_sched: step failed; canceling build");
+            state->building = false;
+            state->nodes_relaxed_accum = 0u;
+            state->elapsed_ms_accum = 0.0;
+        }
+    } else {
+        bool should_start = state->pending_force;
+        if (!should_start) {
+            if (!state->has_data) {
+                state->time_since_last_start_ms = 0.0;
+            } else if (state->cadence_interval_ms <= 0.0) {
+                should_start = true;
+            } else if (state->time_since_last_start_ms >= state->cadence_interval_ms) {
+                should_start = true;
+            }
+        }
+        if (should_start && state->has_data) {
+            if (path_fields_start_build(PATH_GOAL_ENTRANCE,
+                                        state->world,
+                                        state->neighbors,
+                                        state->goals,
+                                        state->goal_count)) {
+                state->building = true;
+                state->nodes_relaxed_accum = 0u;
+                state->elapsed_ms_accum = 0.0;
+                state->time_since_last_start_ms = 0.0;
+                state->pending_force = false;
+                size_t relaxed = 0u;
+                double step_ms = 0.0;
+                bool finished = false;
+                if (path_fields_step(PATH_GOAL_ENTRANCE,
+                                      g_sched.budget_ms,
+                                      &relaxed,
+                                      &step_ms,
+                                      &finished)) {
+                    state->nodes_relaxed_accum += relaxed;
+                    state->elapsed_ms_accum += step_ms;
+                    if (finished) {
+                        state->last_relaxed = state->nodes_relaxed_accum;
+                        state->last_build_ms = (float)state->elapsed_ms_accum;
+                        state->nodes_relaxed_accum = 0u;
+                        state->elapsed_ms_accum = 0.0;
+                        state->building = false;
+                        swapped = true;
+                    }
+                } else {
+                    LOG_WARN("path_sched: step failed immediately after start");
+                    state->building = false;
+                    state->nodes_relaxed_accum = 0u;
+                    state->elapsed_ms_accum = 0.0;
+                }
+            } else {
+                state->pending_force = true;
+                state->time_since_last_start_ms = 0.0;
+            }
+        }
+    }
+
+    if (out_field_swapped) {
+        *out_field_swapped = swapped;
+    }
+    return true;
+}
+
+void path_sched_set_budget_ms(float per_frame_ms) {
+    if (per_frame_ms < 0.0f) {
+        per_frame_ms = 0.0f;
+    }
+    g_sched.budget_ms = per_frame_ms;
+}
+
+void path_sched_set_cadence(PathGoal goal, float Hz) {
+    PathSchedGoalState *state = get_goal_state(goal);
+    if (!state) {
+        return;
+    }
+    state->cadence_hz = (Hz > 0.0f) ? Hz : 0.0f;
+    state->cadence_interval_ms = cadence_to_interval(state->cadence_hz);
+    state->time_since_last_start_ms = 0.0;
+}
+
+float path_sched_get_last_build_ms(PathGoal goal) {
+    PathSchedGoalState *state = get_goal_state(goal);
+    if (!state) {
+        return 0.0f;
+    }
+    return state->last_build_ms;
+}
+
+size_t path_sched_get_last_relaxed(PathGoal goal) {
+    PathSchedGoalState *state = get_goal_state(goal);
+    if (!state) {
+        return 0u;
+    }
+    return state->last_relaxed;
+}
+
+bool path_sched_is_building(PathGoal goal) {
+    PathSchedGoalState *state = get_goal_state(goal);
+    if (!state) {
+        return false;
+    }
+    return state->building;
+}
+
+uint32_t path_sched_get_stamp(PathGoal goal) {
+    return path_field_stamp(goal);
+}
+
+void path_sched_force_full_recompute(PathGoal goal) {
+    PathSchedGoalState *state = get_goal_state(goal);
+    if (!state) {
+        return;
+    }
+    state->pending_force = true;
+    if (!state->has_data) {
+        return;
+    }
+    if (path_fields_start_build(goal, state->world, state->neighbors, state->goals, state->goal_count)) {
+        state->building = true;
+        state->nodes_relaxed_accum = 0u;
+        state->elapsed_ms_accum = 0.0;
+        state->time_since_last_start_ms = 0.0;
+        state->pending_force = false;
+    }
+}

--- a/src/path/path_scheduler.c
+++ b/src/path/path_scheduler.c
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "path/path_fields.h"
 #include "path/path_internal.h"
@@ -23,20 +24,23 @@ typedef struct PathSchedGoalState {
     double elapsed_ms_accum;
     float last_build_ms;
     size_t last_relaxed;
-    TileId *dirty_tiles;
-    size_t dirty_capacity;
-    size_t current_dirty_seed_count;
     size_t last_dirty_processed;
+    size_t dirty_seed_count_active;
 } PathSchedGoalState;
 
 typedef struct PathSchedulerState {
     float budget_ms;
     PathSchedGoalState goals[PATH_GOAL_COUNT];
+    TileId *shared_dirty_tiles;
+    size_t shared_dirty_capacity;
+    size_t shared_dirty_count;
+    bool shared_dirty_valid;
+    bool shared_dirty_used[PATH_GOAL_COUNT];
 } PathSchedulerState;
 
 static PathSchedulerState g_sched = {0};
 
-static const float kDefaultCadenceHz[PATH_GOAL_COUNT] = {10.0f};
+static const float kDefaultCadenceHz[PATH_GOAL_COUNT] = {10.0f, 6.0f};
 
 static inline double cadence_to_interval(float hz) {
     return (hz > 0.0f) ? (1000.0 / (double)hz) : 0.0;
@@ -49,66 +53,108 @@ static PathSchedGoalState *get_goal_state(PathGoal goal) {
     return &g_sched.goals[goal];
 }
 
-static void clear_goal_state(PathSchedGoalState *state) {
+static void clear_goal_state(PathSchedGoalState *state, int goal_index) {
     if (!state) {
         return;
     }
-    free(state->dirty_tiles);
-    state->dirty_tiles = NULL;
-    state->dirty_capacity = 0u;
-    state->current_dirty_seed_count = 0u;
+    if (path_fields_is_building((PathGoal)goal_index)) {
+        path_fields_cancel_build((PathGoal)goal_index);
+    }
+    state->cadence_hz = (goal_index < (int)(sizeof kDefaultCadenceHz / sizeof kDefaultCadenceHz[0]))
+                            ? kDefaultCadenceHz[goal_index]
+                            : 0.0f;
+    state->cadence_interval_ms = cadence_to_interval(state->cadence_hz);
+    state->time_since_last_start_ms = 0.0;
+    state->building = false;
+    state->pending_force = false;
+    state->has_data = false;
+    state->world = NULL;
+    state->neighbors = NULL;
+    state->goals = NULL;
+    state->goal_count = 0u;
+    state->tile_count = 0u;
+    state->nodes_relaxed_accum = 0u;
+    state->elapsed_ms_accum = 0.0;
+    state->last_build_ms = 0.0f;
+    state->last_relaxed = 0u;
     state->last_dirty_processed = 0u;
+    state->dirty_seed_count_active = 0u;
 }
 
-static bool ensure_dirty_capacity(PathSchedGoalState *state, size_t needed) {
-    if (!state) {
-        return false;
-    }
+static void reset_shared_batch(void) {
+    g_sched.shared_dirty_count = 0u;
+    g_sched.shared_dirty_valid = false;
+    memset(g_sched.shared_dirty_used, 0, sizeof(g_sched.shared_dirty_used));
+}
+
+static bool ensure_shared_capacity(size_t needed) {
     if (needed == 0u) {
         return true;
     }
-    if (state->dirty_capacity >= needed) {
+    if (g_sched.shared_dirty_capacity >= needed) {
         return true;
     }
-    size_t new_capacity = state->dirty_capacity ? state->dirty_capacity : 256u;
+    size_t new_capacity = g_sched.shared_dirty_capacity ? g_sched.shared_dirty_capacity : 256u;
     while (new_capacity < needed) {
         new_capacity *= 2u;
     }
-    TileId *tiles = (TileId *)realloc(state->dirty_tiles, new_capacity * sizeof(TileId));
+    TileId *tiles = (TileId *)realloc(g_sched.shared_dirty_tiles, new_capacity * sizeof(TileId));
     if (!tiles) {
-        LOG_ERROR("path_sched: failed to grow dirty buffer (capacity=%zu)", new_capacity);
+        LOG_ERROR("path_sched: failed to grow shared dirty buffer (capacity=%zu)", new_capacity);
         return false;
     }
-    state->dirty_tiles = tiles;
-    state->dirty_capacity = new_capacity;
+    g_sched.shared_dirty_tiles = tiles;
+    g_sched.shared_dirty_capacity = new_capacity;
     return true;
+}
+
+static bool ensure_shared_dirty_batch(size_t max_needed) {
+    if (g_sched.shared_dirty_valid) {
+        return g_sched.shared_dirty_count > 0u;
+    }
+    size_t available = path_cost_dirty_count();
+    if (available == 0u) {
+        return false;
+    }
+    size_t request = available;
+    if (max_needed > 0u && request > max_needed) {
+        request = max_needed;
+    }
+    if (!ensure_shared_capacity(request)) {
+        return false;
+    }
+    size_t consumed = path_cost_consume_dirty(g_sched.shared_dirty_tiles, request);
+    if (consumed == 0u) {
+        return false;
+    }
+    g_sched.shared_dirty_count = consumed;
+    g_sched.shared_dirty_valid = true;
+    memset(g_sched.shared_dirty_used, 0, sizeof(g_sched.shared_dirty_used));
+    return true;
+}
+
+static void finalize_shared_batch_if_consumed(void) {
+    if (!g_sched.shared_dirty_valid) {
+        return;
+    }
+    for (int goal = 0; goal < PATH_GOAL_COUNT; ++goal) {
+        const PathSchedGoalState *state = &g_sched.goals[goal];
+        if (!state->has_data) {
+            continue;
+        }
+        if (!g_sched.shared_dirty_used[goal]) {
+            return;
+        }
+    }
+    reset_shared_batch();
 }
 
 void path_sched_reset_state(void) {
     g_sched.budget_ms = 1.5f;
     for (int i = 0; i < PATH_GOAL_COUNT; ++i) {
-        PathSchedGoalState *state = &g_sched.goals[i];
-        clear_goal_state(state);
-        state->cadence_hz = (i < (int)(sizeof kDefaultCadenceHz / sizeof kDefaultCadenceHz[0]))
-                                ? kDefaultCadenceHz[i]
-                                : 0.0f;
-        state->cadence_interval_ms = cadence_to_interval(state->cadence_hz);
-        state->time_since_last_start_ms = 0.0;
-        state->building = false;
-        state->pending_force = false;
-        state->has_data = false;
-        state->world = NULL;
-        state->neighbors = NULL;
-        state->goals = NULL;
-        state->goal_count = 0u;
-        state->tile_count = 0u;
-        state->nodes_relaxed_accum = 0u;
-        state->elapsed_ms_accum = 0.0;
-        state->last_build_ms = 0.0f;
-        state->last_relaxed = 0u;
-        state->current_dirty_seed_count = 0u;
-        state->last_dirty_processed = 0u;
+        clear_goal_state(&g_sched.goals[i], i);
     }
+    reset_shared_batch();
 }
 
 void path_sched_shutdown_state(void) {
@@ -116,8 +162,11 @@ void path_sched_shutdown_state(void) {
         if (path_fields_is_building((PathGoal)i)) {
             path_fields_cancel_build((PathGoal)i);
         }
-        clear_goal_state(&g_sched.goals[i]);
     }
+    free(g_sched.shared_dirty_tiles);
+    g_sched.shared_dirty_tiles = NULL;
+    g_sched.shared_dirty_capacity = 0u;
+    reset_shared_batch();
     path_sched_reset_state();
 }
 
@@ -144,141 +193,165 @@ void path_sched_set_goal_data(PathGoal goal,
     state->pending_force = false;
     state->nodes_relaxed_accum = 0u;
     state->elapsed_ms_accum = 0.0;
+    state->last_build_ms = 0.0f;
+    state->last_relaxed = 0u;
+    state->last_dirty_processed = 0u;
+    state->dirty_seed_count_active = 0u;
     state->time_since_last_start_ms = 0.0;
-    if (state->has_data) {
-        ensure_dirty_capacity(state, tile_count);
+    if (!state->has_data) {
+        state->cadence_interval_ms = cadence_to_interval(state->cadence_hz);
+    }
+    if (goal >= 0 && goal < PATH_GOAL_COUNT) {
+        g_sched.shared_dirty_used[goal] = false;
     }
 }
 
-bool path_sched_update(float dt_sec, bool *out_field_swapped) {
+static void requeue_shared_dirty(void) {
+    if (!g_sched.shared_dirty_valid || g_sched.shared_dirty_count == 0u) {
+        return;
+    }
+    path_cost_requeue_tiles(g_sched.shared_dirty_tiles, g_sched.shared_dirty_count);
+    reset_shared_batch();
+}
+
+bool path_sched_update(float dt_sec, bool out_field_swapped[PATH_GOAL_COUNT]) {
     if (out_field_swapped) {
-        *out_field_swapped = false;
-    }
-    PathSchedGoalState *state = get_goal_state(PATH_GOAL_ENTRANCE);
-    if (!state) {
-        return false;
-    }
-    double dt_ms = (dt_sec > 0.0f) ? (double)dt_sec * 1000.0 : 0.0;
-    if (!state->building) {
-        state->time_since_last_start_ms += dt_ms;
+        for (int i = 0; i < PATH_GOAL_COUNT; ++i) {
+            out_field_swapped[i] = false;
+        }
     }
 
-    size_t dirty_queue_len = path_cost_dirty_count();
-    bool swapped = false;
-    if (state->building) {
+    double dt_ms = (dt_sec > 0.0f) ? (double)dt_sec * 1000.0 : 0.0;
+    for (int goal = 0; goal < PATH_GOAL_COUNT; ++goal) {
+        PathSchedGoalState *state = &g_sched.goals[goal];
+        if (!state->building) {
+            state->time_since_last_start_ms += dt_ms;
+        }
+    }
+
+    double remaining_budget = g_sched.budget_ms;
+    bool track_budget = (g_sched.budget_ms > 0.0f);
+
+    for (int goal = 0; goal < PATH_GOAL_COUNT; ++goal) {
+        PathSchedGoalState *state = &g_sched.goals[goal];
+        if (!state->has_data) {
+            continue;
+        }
+
+        double goal_budget = track_budget ? remaining_budget : g_sched.budget_ms;
+        if (goal_budget < 0.0) {
+            goal_budget = 0.0;
+        }
+
+        bool stepped = false;
         size_t relaxed = 0u;
         double step_ms = 0.0;
         bool finished = false;
-        if (path_fields_step(PATH_GOAL_ENTRANCE, g_sched.budget_ms, &relaxed, &step_ms, &finished)) {
-            state->nodes_relaxed_accum += relaxed;
-            state->elapsed_ms_accum += step_ms;
-            if (finished) {
-                state->last_relaxed = state->nodes_relaxed_accum;
-                state->last_build_ms = (float)state->elapsed_ms_accum;
+
+        if (state->building) {
+            if (path_fields_step((PathGoal)goal, goal_budget, &relaxed, &step_ms, &finished)) {
+                state->nodes_relaxed_accum += relaxed;
+                state->elapsed_ms_accum += step_ms;
+                stepped = true;
+            } else {
+                LOG_WARN("path_sched: step failed for goal %d; canceling build", goal);
+                state->building = false;
                 state->nodes_relaxed_accum = 0u;
                 state->elapsed_ms_accum = 0.0;
-                state->building = false;
-                state->time_since_last_start_ms = 0.0;
-                state->last_dirty_processed = state->current_dirty_seed_count;
-                state->current_dirty_seed_count = 0u;
-                swapped = true;
+                state->dirty_seed_count_active = 0u;
+                requeue_shared_dirty();
             }
         } else {
-            LOG_WARN("path_sched: step failed; canceling build");
-            state->building = false;
-            state->nodes_relaxed_accum = 0u;
-            state->elapsed_ms_accum = 0.0;
-            if (state->current_dirty_seed_count > 0u) {
-                path_cost_requeue_tiles(state->dirty_tiles, state->current_dirty_seed_count);
-                state->current_dirty_seed_count = 0u;
-            }
-        }
-    } else {
-        bool should_start = state->pending_force;
-        if (!should_start) {
-            if (!state->has_data) {
-                state->time_since_last_start_ms = 0.0;
-            } else if (dirty_queue_len > 0u) {
-                should_start = true;
-            } else if (state->cadence_interval_ms <= 0.0) {
-                should_start = true;
-            } else if (state->time_since_last_start_ms >= state->cadence_interval_ms) {
-                should_start = true;
-            }
-        }
-        if (should_start && state->has_data) {
-            size_t dirty_to_seed = dirty_queue_len;
-            if (dirty_to_seed > state->tile_count) {
-                dirty_to_seed = state->tile_count;
-            }
-            if (ensure_dirty_capacity(state, dirty_to_seed > 0u ? dirty_to_seed : 1u)) {
-                size_t consumed = 0u;
-                if (dirty_to_seed > 0u) {
-                    consumed = path_cost_consume_dirty(state->dirty_tiles, dirty_to_seed);
+            bool has_dirty_batch = g_sched.shared_dirty_valid && !g_sched.shared_dirty_used[goal] &&
+                                   g_sched.shared_dirty_count > 0u;
+            if (!state->pending_force && !has_dirty_batch) {
+                if (!g_sched.shared_dirty_valid && path_cost_dirty_count() > 0u) {
+                    size_t limit = state->tile_count ? state->tile_count : path_cost_dirty_count();
+                    if (ensure_shared_dirty_batch(limit)) {
+                        has_dirty_batch = g_sched.shared_dirty_valid && !g_sched.shared_dirty_used[goal] &&
+                                          g_sched.shared_dirty_count > 0u;
+                    }
                 }
-                const TileId *dirty_ptr = (consumed > 0u) ? state->dirty_tiles : NULL;
-                state->current_dirty_seed_count = consumed;
-                if (path_fields_start_build(PATH_GOAL_ENTRANCE,
+            }
+
+            bool cadence_due = (state->cadence_interval_ms <= 0.0) ||
+                                (state->time_since_last_start_ms >= state->cadence_interval_ms);
+            bool should_start = state->pending_force || has_dirty_batch || cadence_due;
+
+            if (should_start) {
+                const TileId *dirty_ptr = NULL;
+                size_t dirty_count = 0u;
+                if (!state->pending_force && g_sched.shared_dirty_valid && g_sched.shared_dirty_count > 0u &&
+                    !g_sched.shared_dirty_used[goal]) {
+                    dirty_ptr = g_sched.shared_dirty_tiles;
+                    dirty_count = g_sched.shared_dirty_count;
+                    g_sched.shared_dirty_used[goal] = true;
+                }
+
+                if (path_fields_start_build((PathGoal)goal,
                                             state->world,
                                             state->neighbors,
                                             state->goals,
                                             state->goal_count,
                                             path_cost_eff_costs(),
                                             dirty_ptr,
-                                            consumed)) {
+                                            dirty_count)) {
                     state->building = true;
+                    state->pending_force = false;
                     state->nodes_relaxed_accum = 0u;
                     state->elapsed_ms_accum = 0.0;
+                    state->dirty_seed_count_active = dirty_count;
                     state->time_since_last_start_ms = 0.0;
-                    state->pending_force = false;
-                    size_t relaxed = 0u;
-                    double step_ms = 0.0;
-                    bool finished = false;
-                    if (path_fields_step(PATH_GOAL_ENTRANCE,
-                                          g_sched.budget_ms,
-                                          &relaxed,
-                                          &step_ms,
-                                          &finished)) {
+
+                    if (path_fields_step((PathGoal)goal, goal_budget, &relaxed, &step_ms, &finished)) {
                         state->nodes_relaxed_accum += relaxed;
                         state->elapsed_ms_accum += step_ms;
-                        if (finished) {
-                            state->last_relaxed = state->nodes_relaxed_accum;
-                            state->last_build_ms = (float)state->elapsed_ms_accum;
-                            state->nodes_relaxed_accum = 0u;
-                            state->elapsed_ms_accum = 0.0;
-                            state->building = false;
-                            state->last_dirty_processed = state->current_dirty_seed_count;
-                            state->current_dirty_seed_count = 0u;
-                            swapped = true;
-                        }
+                        stepped = true;
                     } else {
-                        LOG_WARN("path_sched: step failed immediately after start");
+                        LOG_WARN("path_sched: step failed immediately for goal %d", goal);
                         state->building = false;
                         state->nodes_relaxed_accum = 0u;
                         state->elapsed_ms_accum = 0.0;
-                        if (state->current_dirty_seed_count > 0u) {
-                            path_cost_requeue_tiles(state->dirty_tiles, state->current_dirty_seed_count);
-                            state->current_dirty_seed_count = 0u;
+                        if (dirty_count > 0u) {
+                            g_sched.shared_dirty_used[goal] = false;
+                            requeue_shared_dirty();
                         }
                     }
                 } else {
-                    if (consumed > 0u) {
-                        path_cost_requeue_tiles(state->dirty_tiles, consumed);
+                    if (dirty_count > 0u) {
+                        g_sched.shared_dirty_used[goal] = false;
+                        requeue_shared_dirty();
                     }
-                    state->current_dirty_seed_count = 0u;
                     state->pending_force = true;
                 }
-            } else {
-                LOG_WARN("path_sched: unable to reserve dirty buffer; deferring build");
-                state->pending_force = true;
+            }
+        }
+
+        if (stepped) {
+            if (track_budget && step_ms > 0.0) {
+                if (step_ms >= remaining_budget) {
+                    remaining_budget = 0.0;
+                } else {
+                    remaining_budget -= step_ms;
+                }
+            }
+            if (finished) {
+                state->last_relaxed = state->nodes_relaxed_accum;
+                state->last_build_ms = (float)state->elapsed_ms_accum;
+                state->nodes_relaxed_accum = 0u;
+                state->elapsed_ms_accum = 0.0;
+                state->building = false;
+                state->last_dirty_processed = state->dirty_seed_count_active;
+                state->dirty_seed_count_active = 0u;
                 state->time_since_last_start_ms = 0.0;
+                if (out_field_swapped) {
+                    out_field_swapped[goal] = true;
+                }
             }
         }
     }
 
-    if (out_field_swapped) {
-        *out_field_swapped = swapped;
-    }
+    finalize_shared_batch_if_consumed();
     return true;
 }
 
@@ -336,7 +409,11 @@ void path_sched_force_full_recompute(PathGoal goal) {
 }
 
 size_t path_sched_get_dirty_queue_len(void) {
-    return path_cost_dirty_count();
+    size_t total = path_cost_dirty_count();
+    if (g_sched.shared_dirty_valid) {
+        total += g_sched.shared_dirty_count;
+    }
+    return total;
 }
 
 size_t path_sched_get_dirty_processed_last_build(PathGoal goal) {

--- a/src/path/path_scheduler.c
+++ b/src/path/path_scheduler.c
@@ -1,6 +1,7 @@
 #include "path/path_scheduler.h"
 
 #include <stddef.h>
+#include <stdlib.h>
 
 #include "path/path_fields.h"
 #include "path/path_internal.h"
@@ -22,6 +23,10 @@ typedef struct PathSchedGoalState {
     double elapsed_ms_accum;
     float last_build_ms;
     size_t last_relaxed;
+    TileId *dirty_tiles;
+    size_t dirty_capacity;
+    size_t current_dirty_seed_count;
+    size_t last_dirty_processed;
 } PathSchedGoalState;
 
 typedef struct PathSchedulerState {
@@ -44,10 +49,46 @@ static PathSchedGoalState *get_goal_state(PathGoal goal) {
     return &g_sched.goals[goal];
 }
 
+static void clear_goal_state(PathSchedGoalState *state) {
+    if (!state) {
+        return;
+    }
+    free(state->dirty_tiles);
+    state->dirty_tiles = NULL;
+    state->dirty_capacity = 0u;
+    state->current_dirty_seed_count = 0u;
+    state->last_dirty_processed = 0u;
+}
+
+static bool ensure_dirty_capacity(PathSchedGoalState *state, size_t needed) {
+    if (!state) {
+        return false;
+    }
+    if (needed == 0u) {
+        return true;
+    }
+    if (state->dirty_capacity >= needed) {
+        return true;
+    }
+    size_t new_capacity = state->dirty_capacity ? state->dirty_capacity : 256u;
+    while (new_capacity < needed) {
+        new_capacity *= 2u;
+    }
+    TileId *tiles = (TileId *)realloc(state->dirty_tiles, new_capacity * sizeof(TileId));
+    if (!tiles) {
+        LOG_ERROR("path_sched: failed to grow dirty buffer (capacity=%zu)", new_capacity);
+        return false;
+    }
+    state->dirty_tiles = tiles;
+    state->dirty_capacity = new_capacity;
+    return true;
+}
+
 void path_sched_reset_state(void) {
     g_sched.budget_ms = 1.5f;
     for (int i = 0; i < PATH_GOAL_COUNT; ++i) {
         PathSchedGoalState *state = &g_sched.goals[i];
+        clear_goal_state(state);
         state->cadence_hz = (i < (int)(sizeof kDefaultCadenceHz / sizeof kDefaultCadenceHz[0]))
                                 ? kDefaultCadenceHz[i]
                                 : 0.0f;
@@ -65,6 +106,8 @@ void path_sched_reset_state(void) {
         state->elapsed_ms_accum = 0.0;
         state->last_build_ms = 0.0f;
         state->last_relaxed = 0u;
+        state->current_dirty_seed_count = 0u;
+        state->last_dirty_processed = 0u;
     }
 }
 
@@ -73,6 +116,7 @@ void path_sched_shutdown_state(void) {
         if (path_fields_is_building((PathGoal)i)) {
             path_fields_cancel_build((PathGoal)i);
         }
+        clear_goal_state(&g_sched.goals[i]);
     }
     path_sched_reset_state();
 }
@@ -101,6 +145,9 @@ void path_sched_set_goal_data(PathGoal goal,
     state->nodes_relaxed_accum = 0u;
     state->elapsed_ms_accum = 0.0;
     state->time_since_last_start_ms = 0.0;
+    if (state->has_data) {
+        ensure_dirty_capacity(state, tile_count);
+    }
 }
 
 bool path_sched_update(float dt_sec, bool *out_field_swapped) {
@@ -116,6 +163,7 @@ bool path_sched_update(float dt_sec, bool *out_field_swapped) {
         state->time_since_last_start_ms += dt_ms;
     }
 
+    size_t dirty_queue_len = path_cost_dirty_count();
     bool swapped = false;
     if (state->building) {
         size_t relaxed = 0u;
@@ -131,6 +179,8 @@ bool path_sched_update(float dt_sec, bool *out_field_swapped) {
                 state->elapsed_ms_accum = 0.0;
                 state->building = false;
                 state->time_since_last_start_ms = 0.0;
+                state->last_dirty_processed = state->current_dirty_seed_count;
+                state->current_dirty_seed_count = 0u;
                 swapped = true;
             }
         } else {
@@ -138,12 +188,18 @@ bool path_sched_update(float dt_sec, bool *out_field_swapped) {
             state->building = false;
             state->nodes_relaxed_accum = 0u;
             state->elapsed_ms_accum = 0.0;
+            if (state->current_dirty_seed_count > 0u) {
+                path_cost_requeue_tiles(state->dirty_tiles, state->current_dirty_seed_count);
+                state->current_dirty_seed_count = 0u;
+            }
         }
     } else {
         bool should_start = state->pending_force;
         if (!should_start) {
             if (!state->has_data) {
                 state->time_since_last_start_ms = 0.0;
+            } else if (dirty_queue_len > 0u) {
+                should_start = true;
             } else if (state->cadence_interval_ms <= 0.0) {
                 should_start = true;
             } else if (state->time_since_last_start_ms >= state->cadence_interval_ms) {
@@ -151,41 +207,69 @@ bool path_sched_update(float dt_sec, bool *out_field_swapped) {
             }
         }
         if (should_start && state->has_data) {
-            if (path_fields_start_build(PATH_GOAL_ENTRANCE,
-                                        state->world,
-                                        state->neighbors,
-                                        state->goals,
-                                        state->goal_count)) {
-                state->building = true;
-                state->nodes_relaxed_accum = 0u;
-                state->elapsed_ms_accum = 0.0;
-                state->time_since_last_start_ms = 0.0;
-                state->pending_force = false;
-                size_t relaxed = 0u;
-                double step_ms = 0.0;
-                bool finished = false;
-                if (path_fields_step(PATH_GOAL_ENTRANCE,
-                                      g_sched.budget_ms,
-                                      &relaxed,
-                                      &step_ms,
-                                      &finished)) {
-                    state->nodes_relaxed_accum += relaxed;
-                    state->elapsed_ms_accum += step_ms;
-                    if (finished) {
-                        state->last_relaxed = state->nodes_relaxed_accum;
-                        state->last_build_ms = (float)state->elapsed_ms_accum;
-                        state->nodes_relaxed_accum = 0u;
-                        state->elapsed_ms_accum = 0.0;
-                        state->building = false;
-                        swapped = true;
-                    }
-                } else {
-                    LOG_WARN("path_sched: step failed immediately after start");
-                    state->building = false;
+            size_t dirty_to_seed = dirty_queue_len;
+            if (dirty_to_seed > state->tile_count) {
+                dirty_to_seed = state->tile_count;
+            }
+            if (ensure_dirty_capacity(state, dirty_to_seed > 0u ? dirty_to_seed : 1u)) {
+                size_t consumed = 0u;
+                if (dirty_to_seed > 0u) {
+                    consumed = path_cost_consume_dirty(state->dirty_tiles, dirty_to_seed);
+                }
+                const TileId *dirty_ptr = (consumed > 0u) ? state->dirty_tiles : NULL;
+                state->current_dirty_seed_count = consumed;
+                if (path_fields_start_build(PATH_GOAL_ENTRANCE,
+                                            state->world,
+                                            state->neighbors,
+                                            state->goals,
+                                            state->goal_count,
+                                            path_cost_eff_costs(),
+                                            dirty_ptr,
+                                            consumed)) {
+                    state->building = true;
                     state->nodes_relaxed_accum = 0u;
                     state->elapsed_ms_accum = 0.0;
+                    state->time_since_last_start_ms = 0.0;
+                    state->pending_force = false;
+                    size_t relaxed = 0u;
+                    double step_ms = 0.0;
+                    bool finished = false;
+                    if (path_fields_step(PATH_GOAL_ENTRANCE,
+                                          g_sched.budget_ms,
+                                          &relaxed,
+                                          &step_ms,
+                                          &finished)) {
+                        state->nodes_relaxed_accum += relaxed;
+                        state->elapsed_ms_accum += step_ms;
+                        if (finished) {
+                            state->last_relaxed = state->nodes_relaxed_accum;
+                            state->last_build_ms = (float)state->elapsed_ms_accum;
+                            state->nodes_relaxed_accum = 0u;
+                            state->elapsed_ms_accum = 0.0;
+                            state->building = false;
+                            state->last_dirty_processed = state->current_dirty_seed_count;
+                            state->current_dirty_seed_count = 0u;
+                            swapped = true;
+                        }
+                    } else {
+                        LOG_WARN("path_sched: step failed immediately after start");
+                        state->building = false;
+                        state->nodes_relaxed_accum = 0u;
+                        state->elapsed_ms_accum = 0.0;
+                        if (state->current_dirty_seed_count > 0u) {
+                            path_cost_requeue_tiles(state->dirty_tiles, state->current_dirty_seed_count);
+                            state->current_dirty_seed_count = 0u;
+                        }
+                    }
+                } else {
+                    if (consumed > 0u) {
+                        path_cost_requeue_tiles(state->dirty_tiles, consumed);
+                    }
+                    state->current_dirty_seed_count = 0u;
+                    state->pending_force = true;
                 }
             } else {
+                LOG_WARN("path_sched: unable to reserve dirty buffer; deferring build");
                 state->pending_force = true;
                 state->time_since_last_start_ms = 0.0;
             }
@@ -249,14 +333,16 @@ void path_sched_force_full_recompute(PathGoal goal) {
         return;
     }
     state->pending_force = true;
-    if (!state->has_data) {
-        return;
+}
+
+size_t path_sched_get_dirty_queue_len(void) {
+    return path_cost_dirty_count();
+}
+
+size_t path_sched_get_dirty_processed_last_build(PathGoal goal) {
+    PathSchedGoalState *state = get_goal_state(goal);
+    if (!state) {
+        return 0u;
     }
-    if (path_fields_start_build(goal, state->world, state->neighbors, state->goals, state->goal_count)) {
-        state->building = true;
-        state->nodes_relaxed_accum = 0u;
-        state->elapsed_ms_accum = 0.0;
-        state->time_since_last_start_ms = 0.0;
-        state->pending_force = false;
-    }
+    return state->last_dirty_processed;
 }

--- a/src/sim/sim_internal.h
+++ b/src/sim/sim_internal.h
@@ -77,6 +77,13 @@ typedef struct SimState {
     float bee_speed_mps;
     float bee_seek_accel;
     float bee_arrive_tol_world;
+    int32_t *bee_tile_index;
+    uint32_t *tile_crossings;
+    TileId *congestion_tiles;
+    float *congestion_rates;
+    size_t congestion_capacity;
+    size_t world_tile_count;
+    double congestion_accum_sec;
 } SimState;
 
 static inline float clampf(float v, float lo, float hi) {


### PR DESCRIPTION
## Summary
- add the initial path module with entrance-only flow-field storage, Dijkstra solver, and overlay utilities
- integrate the path system with app initialization, runtime rebuilds, and per-frame debug rendering
- register the new path sources with the build
- add double-buffered entrance field recomputes with a time-sliced scheduler and per-frame `path_update` hook
- expose scheduler controls/stats, force-recompute support, and refresh the debug overlay when fields swap

## Testing
- `cmake -S . -B build` *(fails: missing SDL2 package in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fa69543980832ba90c31ea0a710525